### PR TITLE
Fw 491

### DIFF
--- a/vaadin-bootstrap-datetimerangepicker-demo/src/main/java/org/vaadin/addons/datetimerangepicker/DemoUI.java
+++ b/vaadin-bootstrap-datetimerangepicker-demo/src/main/java/org/vaadin/addons/datetimerangepicker/DemoUI.java
@@ -204,6 +204,8 @@ public class DemoUI extends UI {
                     .alwaysShowCalendars(DemoUI.this.checkAlwaysShowCalendars.getValue())
                     .showCustomRangeLabel(DemoUI.this.checkShowCustomRangeLabel.getValue());
 
+                dateRangeField.setEnabled(false);
+
                 bean.setDateTimeRange(new DateTimeRange(DemoUI.this.startDateField.getValue(), DemoUI.this.endDateField.getValue()));
                 fieldGroup.bind(DemoUI.this.dateRangeField, "dateTimeRange");
             }

--- a/vaadin-bootstrap-datetimerangepicker-demo/src/main/java/org/vaadin/addons/datetimerangepicker/DemoUI.java
+++ b/vaadin-bootstrap-datetimerangepicker-demo/src/main/java/org/vaadin/addons/datetimerangepicker/DemoUI.java
@@ -112,6 +112,7 @@ public class DemoUI extends UI {
     private CheckBox checkAutoApply;
     private CheckBox checkLinkedCalendars;
     private CheckBox checkAutoUpdateInput;
+    private CheckBox checkEnabled;
 
     private TextField textButtonClasses;
     private TextField textApplyClass;
@@ -201,10 +202,11 @@ public class DemoUI extends UI {
                     .applyClass(DemoUI.this.textApplyClass.getValue())
                     .cancelClass(DemoUI.this.textCancelClass.getValue())
                     .ranges(ranges)
+                    .workable(DemoUI.this.checkEnabled.getValue())
                     .alwaysShowCalendars(DemoUI.this.checkAlwaysShowCalendars.getValue())
                     .showCustomRangeLabel(DemoUI.this.checkShowCustomRangeLabel.getValue());
 
-                dateRangeField.setEnabled(false);
+                dateRangeField.setEnabled(DemoUI.this.checkEnabled.getValue());
 
                 bean.setDateTimeRange(new DateTimeRange(DemoUI.this.startDateField.getValue(), DemoUI.this.endDateField.getValue()));
                 fieldGroup.bind(DemoUI.this.dateRangeField, "dateTimeRange");
@@ -310,6 +312,11 @@ public class DemoUI extends UI {
         this.checkAutoUpdateInput.setValue(true);
         this.checkAutoUpdateInput.addValueChangeListener(valueChangeListener);
 
+        // Checkbox enabled
+        this.checkEnabled = new CheckBox("enabled");
+        this.checkEnabled.setValue(true);
+        this.checkEnabled.addValueChangeListener(valueChangeListener);
+
         // Textfield buttonClasses
         this.textButtonClasses = new TextField("buttonClasses");
         this.textButtonClasses.setValue("btn btn-sm");
@@ -395,6 +402,7 @@ public class DemoUI extends UI {
         middleLayout.addComponent(this.checkAutoApply);
         middleLayout.addComponent(this.checkLinkedCalendars);
         middleLayout.addComponent(this.checkAutoUpdateInput);
+        middleLayout.addComponent(this.checkEnabled);
 
         VerticalLayout rightLayout = new VerticalLayout();
         rightLayout.setSpacing(true);

--- a/vaadin-bootstrap-datetimerangepicker/pom.xml
+++ b/vaadin-bootstrap-datetimerangepicker/pom.xml
@@ -18,6 +18,7 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<vaadin.version>7.7.3</vaadin.version>
 		<vaadin.plugin.version>7.7.3</vaadin.plugin.version>
+        <gwt.style>DETAILED</gwt.style>
 
 		<!-- ZIP Manifest fields -->
 		<Implementation-Version>${project.version}</Implementation-Version>

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
@@ -369,6 +369,16 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     }
 
     /**
+     * 
+     * @param workable if the component is enabled or disabled.
+     * @return Instance of {@link DateTimeRangeField}
+     */
+    public DateTimeRangeField workable(final boolean workable) {
+        getState().setWorkable(workable);
+        return this;
+    }
+
+    /**
      * @param timePickerIncrement Increment of the minutes selection list for times (i.e. 30 to allow only selection of times ending in 0 or 30).
      * @return Instance of {@link DateTimeRangeField}
      */
@@ -431,4 +441,5 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         final String result = (date != null ? getDateFormatter().format(date) : DateTimeRangeField.EMPTY_STRING);
         return result;
     }
+
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
@@ -60,10 +60,13 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
     public void onStateChanged(final StateChangeEvent stateChangeEvent) {
         super.onStateChanged(stateChangeEvent);
 
-        getWidget().refresh(getState().getLanguage(), getState().getApplyLabel(), getState().getCancelLabel(), getState().getParentEl(), getState().getStartDate(),
-                            getState().getEndDate(), getState().getMinDate(), getState().getMaxDate(), getState().isShowDropdowns(),
+        getWidget().refresh(getState().getLanguage(), getState().getApplyLabel(), getState().getCancelLabel(), getState().getParentEl(),
+                            getState().getStartDate(), getState().getEndDate(), getState().getMinDate(), getState().getMaxDate(), getState().isShowDropdowns(),
                             getState().isShowWeekNumbers(), getState().isShowISOWeekNumbers(), getState().isSingleDatePicker(), getState().isTimePicker(),
-                            getState().isTimePicker24Hour(), getState().getTimePickerIncrement(), getState().isTimePickerSeconds(), getState().getDateLimitSpanMoment(), getState().getDateLimitSpanValue(), getState().isAutoApply(),
-                            getState().isLinkedCalendars(), getState().isAutoUpdateInput(), getState().getOpens(), getState().getDrops(), getState().getButtonClasses(), getState().getApplyClass(), getState().getCancelClass(), getState().getDateRanges(), getState().isAlwaysShowCalendars(), getState().isShowCustomRangeLabel(), getState().getDatePattern());
+                            getState().isTimePicker24Hour(), getState().getTimePickerIncrement(), getState().isTimePickerSeconds(),
+                            getState().getDateLimitSpanMoment(), getState().getDateLimitSpanValue(), getState().isAutoApply(), getState().isLinkedCalendars(),
+                            getState().isAutoUpdateInput(), getState().getOpens(), getState().getDrops(), getState().getButtonClasses(),
+                            getState().getApplyClass(), getState().getCancelClass(), getState().getDateRanges(), getState().isAlwaysShowCalendars(),
+                            getState().isShowCustomRangeLabel(), getState().getDatePattern(), getState().enabled);
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
@@ -67,6 +67,6 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
                             getState().getDateLimitSpanMoment(), getState().getDateLimitSpanValue(), getState().isAutoApply(), getState().isLinkedCalendars(),
                             getState().isAutoUpdateInput(), getState().getOpens(), getState().getDrops(), getState().getButtonClasses(),
                             getState().getApplyClass(), getState().getCancelClass(), getState().getDateRanges(), getState().isAlwaysShowCalendars(),
-                            getState().isShowCustomRangeLabel(), getState().getDatePattern(), getState().enabled);
+                            getState().isShowCustomRangeLabel(), getState().getDatePattern(), getState().isWorkable());
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldState.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldState.java
@@ -44,6 +44,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
     private boolean singleDatePicker = false;
     private boolean timePicker = false;
     private boolean timePicker24Hour = false;
+    private boolean workable = true; // can't use the name 'enable' because strange inheritance behavior java->javascript.
     //
     private int timePickerIncrement = 1;
     //
@@ -312,4 +313,13 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
     public void setDatePattern(String datePattern) {
         this.datePattern = datePattern;
     }
+
+    public boolean isWorkable() {
+        return workable;
+    }
+
+    public void setWorkable(boolean workable) {
+        this.workable = workable;
+    }
+
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -16,6 +16,8 @@ public class VDateTimeRangeField extends TextBoxBase {
 
     private DateRangeFieldClientUpdateValueHandler updateValueHandler;
 
+    private String elementId;
+
     private final com.google.gwt.user.client.Element inputText;
 
     /*
@@ -33,7 +35,8 @@ public class VDateTimeRangeField extends TextBoxBase {
         com.google.gwt.user.client.Element i = DOM.createElement("i");
         i.addClassName("glyphicon glyphicon-calendar fa fa-calendar");
         getElement().appendChild(i);
-
+        this.elementId = "4711ID"; // TODO randomize or count up the id;
+        this.inputText.setId(elementId);
         setStylePrimaryName("bp-datetimerangepicker");
     }
 
@@ -47,59 +50,60 @@ public class VDateTimeRangeField extends TextBoxBase {
             boolean showDropdowns, boolean showWeekNumbers, boolean showISOWeekNumbers, boolean singleDatePicker, boolean timePicker, boolean timePicker24Hour,
             int timePickerIncrement, boolean timePickerSeconds, String dateLimit, boolean autoApply, boolean linkedCalendars, boolean autoUpdateInput,
             String opens, String drops, String buttonClasses, String applyClass, String cancelClass, String ranges, boolean alwaysShowCalendars,
-            boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean enabled) /*-{
-                                                                                                                      var _this = this;
-                                                                                                                      
-                                                                                                                      $wnd.moment.locale(language);
-                                                                                                                      
-                                                                                                                      configString = '{' +
-                                                                                                                      '"showDropdowns": ' + showDropdowns + ',' +
-                                                                                                                      '"showWeekNumbers": ' + showWeekNumbers + ',' +
-                                                                                                                      '"showISOWeekNumbers": ' + showISOWeekNumbers + ',' +
-                                                                                                                      '"singleDatePicker": ' + singleDatePicker + ',' +
-                                                                                                                      '"timePicker": ' + timePicker + ',' +
-                                                                                                                      '"timePicker24Hour": ' + timePicker24Hour + ',' +
-                                                                                                                      '"timePickerIncrement": ' + timePickerIncrement + ',' +
-                                                                                                                      '"timePickerSeconds": ' + timePickerSeconds + ',' +
-                                                                                                                      (typeof(dateLimit) === 'undefined' || dateLimit.length == 0 ? '' : '"dateLimit": ' + dateLimit + ',') +
-                                                                                                                      '"autoApply": ' + autoApply + ',' +
-                                                                                                                      '"linkedCalendars": ' + linkedCalendars + ',' +
-                                                                                                                      '"autoUpdateInput": ' + autoUpdateInput + ',' +
-                                                                                                                      '"opens": "' + opens + '",' +
-                                                                                                                      '"drops": "' + drops + '",' +
-                                                                                                                      '"parentEl": "' + parentEl + '",' +
-                                                                                                                      (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
-                                                                                                                      (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
-                                                                                                                      (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
-                                                                                                                      (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
-                                                                                                                      '"buttonClasses": "' + buttonClasses + '",' +
-                                                                                                                      '"applyClass": "' + applyClass + '",' +
-                                                                                                                      '"cancelClass": "' + cancelClass + '",' +
-                                                                                                                      (typeof(ranges) === 'undefined' || ranges.length == 0 ? '' : '"ranges": ' + ranges + ',') +
-                                                                                                                      '"alwaysShowCalendars": ' + alwaysShowCalendars + ',' +
-                                                                                                                      '"showCustomRangeLabel": ' + showCustomRangeLabel + ',' +
-                                                                                                                      '"locale": { "applyLabel": "' + applyLabel + '",' +
-                                                                                                                      '"cancelLabel": "' + cancelLabel + '"}' + ',' +
-                                                                                                                      '"format": "' + datePattern + '"' +
-                                                                                                                      '}';
-                                                                                                                      
-                                                                                                                      window.console.log(configString);
-                                                                                                                      
-                                                                                                                      $wnd.$(node).daterangepicker(JSON.parse(configString),
-                                                                                                                      function(start, end, label) {
-                                                                                                                      _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
-                                                                                                                      });
-                                                                                                                      
-                                                                                                                      
-                                                                                                                      
-                                                                                                                      $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
+            boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean workable) /*-{
+                                                                                                                       var _this = this;
+                                                                                                                       
+                                                                                                                       $wnd.moment.locale(language);
+                                                                                                                       
+                                                                                                                       configString = '{' +
+                                                                                                                       '"showDropdowns": ' + showDropdowns + ',' +
+                                                                                                                       '"showWeekNumbers": ' + showWeekNumbers + ',' +
+                                                                                                                       '"showISOWeekNumbers": ' + showISOWeekNumbers + ',' +
+                                                                                                                       '"singleDatePicker": ' + singleDatePicker + ',' +
+                                                                                                                       '"timePicker": ' + timePicker + ',' +
+                                                                                                                       '"timePicker24Hour": ' + timePicker24Hour + ',' +
+                                                                                                                       '"timePickerIncrement": ' + timePickerIncrement + ',' +
+                                                                                                                       '"timePickerSeconds": ' + timePickerSeconds + ',' +
+                                                                                                                       (typeof(dateLimit) === 'undefined' || dateLimit.length == 0 ? '' : '"dateLimit": ' + dateLimit + ',') +
+                                                                                                                       '"autoApply": ' + autoApply + ',' +
+                                                                                                                       '"linkedCalendars": ' + linkedCalendars + ',' +
+                                                                                                                       '"autoUpdateInput": ' + autoUpdateInput + ',' +
+                                                                                                                       '"opens": "' + opens + '",' +
+                                                                                                                       '"drops": "' + drops + '",' +
+                                                                                                                       '"parentEl": "' + parentEl + '",' +
+                                                                                                                       (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
+                                                                                                                       (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
+                                                                                                                       (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
+                                                                                                                       (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
+                                                                                                                       '"buttonClasses": "' + buttonClasses + '",' +
+                                                                                                                       '"applyClass": "' + applyClass + '",' +
+                                                                                                                       '"cancelClass": "' + cancelClass + '",' +
+                                                                                                                       (typeof(ranges) === 'undefined' || ranges.length == 0 ? '' : '"ranges": ' + ranges + ',') +
+                                                                                                                       '"alwaysShowCalendars": ' + alwaysShowCalendars + ',' +
+                                                                                                                       '"showCustomRangeLabel": ' + showCustomRangeLabel + ',' +
+                                                                                                                       '"locale": { "applyLabel": "' + applyLabel + '",' +
+                                                                                                                       '"cancelLabel": "' + cancelLabel + '"}' + ',' +
+                                                                                                                       '"format": "' + datePattern + '"' +
+                                                                                                                       '}';
+                                                                                                                       
+                                                                                                                       console.log(configString);
+                                                                                                                       
+                                                                                                                       $wnd.$(node).daterangepicker(JSON.parse(configString),
+                                                                                                                       function(start, end, label) {
+                                                                                                                       _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
+                                                                                                                       });
+                                                                                                                       
+                                                                                                                       
+                                                                                                                       
+                                                                                                                       $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
                                                                                                                           $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
-                                                                                                                      });
-                                                                                                                      
-                                                                                                                       $wnd.alert("Enabled ist: " + enabled);
+                                                                                                                       });
+                                                                                                                       
+                                                                                                                       $wnd.alert("Enabled ist: " + workable);
                                                                                                                        $wnd.$(node).disabled=true;
-                                                                                                                      
-                                                                                                                      }-*/;
+                                                                                                                       document.getElementById( "4711ID" ).disabled=true;
+                                                                                                                       
+                                                                                                                       }-*/;
 
     private void onUpdateValue(final JsDate start, final JsDate end) {
         this.updateValueHandler.onUpdateValue(start, end);
@@ -117,7 +121,7 @@ public class VDateTimeRangeField extends TextBoxBase {
             final int timePickerIncrement, final boolean timePickerSeconds, final String dateLimitSpanMoment, final int dateLimitSpanValue,
             final boolean autoApply, final boolean linkedCalendars, final boolean autoUpdateInput, final String opens, final String drops,
             final String buttonClasses, final String applyClass, final String cancelClass, final Map<String, List<String>> dateRanges,
-            final boolean alwaysShowCalendars, final boolean showCustomRangeLabels, final String datePattern, final boolean enabled) {
+            final boolean alwaysShowCalendars, final boolean showCustomRangeLabels, final String datePattern, final boolean workable) {
 
         // DateLimit Processing
         String dateLimit = "";
@@ -155,9 +159,9 @@ public class VDateTimeRangeField extends TextBoxBase {
             ranges += "}";
         }
 
-        this.setEnabled(enabled);
+        this.setEnabled(workable);
         init(this.inputText, language, parentEl, startDate, endDate, minDate, maxDate, showDropdowns, showWeekNumbers, showISOWeekNumbers, singleDatePicker,
              timePicker, timePicker24Hour, timePickerIncrement, timePickerSeconds, dateLimit, autoApply, linkedCalendars, autoUpdateInput, opens, drops,
-             buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, enabled);
+             buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, workable);
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -41,61 +41,71 @@ public class VDateTimeRangeField extends TextBoxBase {
         this.updateValueHandler = updateValueHandler;
     }
 
+    // document.getElementById("btnPlaceOrder").disabled = true;
+
     private native void init(Element node, String language, String parentEl, String startDate, String endDate, String minDate, String maxDate,
             boolean showDropdowns, boolean showWeekNumbers, boolean showISOWeekNumbers, boolean singleDatePicker, boolean timePicker, boolean timePicker24Hour,
             int timePickerIncrement, boolean timePickerSeconds, String dateLimit, boolean autoApply, boolean linkedCalendars, boolean autoUpdateInput,
             String opens, String drops, String buttonClasses, String applyClass, String cancelClass, String ranges, boolean alwaysShowCalendars,
-            boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern) /*-{
-                                          var _this = this;
-
-                                          $wnd.moment.locale(language);
-
-                                          configString = '{' +
-                                          '"showDropdowns": ' + showDropdowns + ',' +
-                                          '"showWeekNumbers": ' + showWeekNumbers + ',' +
-                                          '"showISOWeekNumbers": ' + showISOWeekNumbers + ',' +
-                                          '"singleDatePicker": ' + singleDatePicker + ',' +
-                                          '"timePicker": ' + timePicker + ',' +
-                                          '"timePicker24Hour": ' + timePicker24Hour + ',' +
-                                          '"timePickerIncrement": ' + timePickerIncrement + ',' +
-                                          '"timePickerSeconds": ' + timePickerSeconds + ',' +
-                                          (typeof(dateLimit) === 'undefined' || dateLimit.length == 0 ? '' : '"dateLimit": ' + dateLimit + ',') +
-                                          '"autoApply": ' + autoApply + ',' +
-                                          '"linkedCalendars": ' + linkedCalendars + ',' +
-                                          '"autoUpdateInput": ' + autoUpdateInput + ',' +
-                                          '"opens": "' + opens + '",' +
-                                          '"drops": "' + drops + '",' +
-                                          '"parentEl": "' + parentEl + '",' +
-                                          (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
-                                          (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
-                                          (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
-                                          (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
-                                          '"buttonClasses": "' + buttonClasses + '",' +
-                                          '"applyClass": "' + applyClass + '",' +
-                                          '"cancelClass": "' + cancelClass + '",' +
-                                          (typeof(ranges) === 'undefined' || ranges.length == 0 ? '' : '"ranges": ' + ranges + ',') +
-                                          '"alwaysShowCalendars": ' + alwaysShowCalendars + ',' +
-                                          '"showCustomRangeLabel": ' + showCustomRangeLabel + ',' +
-                                          '"locale": { "applyLabel": "' + applyLabel + '",' +
-                                              '"cancelLabel": "' + cancelLabel + '"}' + ',' +
-                                          '"format": "' + datePattern + '"' +
-                                          '}';
-
-                                          console.log(configString)
-
-                                          $wnd.$(node).daterangepicker(JSON.parse(configString),
-                                          function(start, end, label) {
-                                          _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
-                                          });
-
-                                          $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
-                                          $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
-                                          });
-                                          }-*/;
+            boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean enabled) /*-{
+                                                                                                                      var _this = this;
+                                                                                                                      
+                                                                                                                      $wnd.moment.locale(language);
+                                                                                                                      
+                                                                                                                      configString = '{' +
+                                                                                                                      '"showDropdowns": ' + showDropdowns + ',' +
+                                                                                                                      '"showWeekNumbers": ' + showWeekNumbers + ',' +
+                                                                                                                      '"showISOWeekNumbers": ' + showISOWeekNumbers + ',' +
+                                                                                                                      '"singleDatePicker": ' + singleDatePicker + ',' +
+                                                                                                                      '"timePicker": ' + timePicker + ',' +
+                                                                                                                      '"timePicker24Hour": ' + timePicker24Hour + ',' +
+                                                                                                                      '"timePickerIncrement": ' + timePickerIncrement + ',' +
+                                                                                                                      '"timePickerSeconds": ' + timePickerSeconds + ',' +
+                                                                                                                      (typeof(dateLimit) === 'undefined' || dateLimit.length == 0 ? '' : '"dateLimit": ' + dateLimit + ',') +
+                                                                                                                      '"autoApply": ' + autoApply + ',' +
+                                                                                                                      '"linkedCalendars": ' + linkedCalendars + ',' +
+                                                                                                                      '"autoUpdateInput": ' + autoUpdateInput + ',' +
+                                                                                                                      '"opens": "' + opens + '",' +
+                                                                                                                      '"drops": "' + drops + '",' +
+                                                                                                                      '"parentEl": "' + parentEl + '",' +
+                                                                                                                      (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
+                                                                                                                      (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
+                                                                                                                      (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
+                                                                                                                      (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
+                                                                                                                      '"buttonClasses": "' + buttonClasses + '",' +
+                                                                                                                      '"applyClass": "' + applyClass + '",' +
+                                                                                                                      '"cancelClass": "' + cancelClass + '",' +
+                                                                                                                      (typeof(ranges) === 'undefined' || ranges.length == 0 ? '' : '"ranges": ' + ranges + ',') +
+                                                                                                                      '"alwaysShowCalendars": ' + alwaysShowCalendars + ',' +
+                                                                                                                      '"showCustomRangeLabel": ' + showCustomRangeLabel + ',' +
+                                                                                                                      '"locale": { "applyLabel": "' + applyLabel + '",' +
+                                                                                                                      '"cancelLabel": "' + cancelLabel + '"}' + ',' +
+                                                                                                                      '"format": "' + datePattern + '"' +
+                                                                                                                      '}';
+                                                                                                                      
+                                                                                                                      window.console.log(configString);
+                                                                                                                      
+                                                                                                                      $wnd.$(node).daterangepicker(JSON.parse(configString),
+                                                                                                                      function(start, end, label) {
+                                                                                                                      _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
+                                                                                                                      });
+                                                                                                                      
+                                                                                                                      
+                                                                                                                      
+                                                                                                                      $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
+                                                                                                                          $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
+                                                                                                                      });
+                                                                                                                      
+                                                                                                                       $wnd.alert("Enabled ist: " + enabled);
+                                                                                                                       $wnd.$(node).disabled=true;
+                                                                                                                      
+                                                                                                                      }-*/;
 
     private void onUpdateValue(final JsDate start, final JsDate end) {
         this.updateValueHandler.onUpdateValue(start, end);
     }
+
+    // _
 
     public static interface DateRangeFieldClientUpdateValueHandler extends EventHandler {
         void onUpdateValue(JsDate start, JsDate end);
@@ -106,16 +116,19 @@ public class VDateTimeRangeField extends TextBoxBase {
             final boolean showISOWeekNumbers, final boolean singleDatePicker, final boolean timePicker, final boolean timePicker24Hour,
             final int timePickerIncrement, final boolean timePickerSeconds, final String dateLimitSpanMoment, final int dateLimitSpanValue,
             final boolean autoApply, final boolean linkedCalendars, final boolean autoUpdateInput, final String opens, final String drops,
-            final String buttonClasses, final String applyClass, final String cancelClass, final Map<String, List<String>> dateRanges, final boolean alwaysShowCalendars,
-            final boolean showCustomRangeLabels, final String datePattern) {
+            final String buttonClasses, final String applyClass, final String cancelClass, final Map<String, List<String>> dateRanges,
+            final boolean alwaysShowCalendars, final boolean showCustomRangeLabels, final String datePattern, final boolean enabled) {
 
         // DateLimit Processing
         String dateLimit = "";
         if (dateLimitSpanMoment != null && !dateLimitSpanMoment.equals(VDateTimeRangeField.EMPTY_STRING)) {
             dateLimit = new StringBuilder().append("{ \"")
-                    .append(dateLimitSpanMoment).append("\": ")
-                    .append(dateLimitSpanValue).append(" }")
-                    .toString();
+                .append(dateLimitSpanMoment)
+
+                .append("\": ")
+                .append(dateLimitSpanValue)
+                .append(" }")
+                .toString();
         }
 
         // Ranges Processing
@@ -126,21 +139,25 @@ public class VDateTimeRangeField extends TextBoxBase {
             for (Map.Entry<String, List<String>> entry : dateRanges.entrySet()) {
                 elementCount++;
                 ranges += new StringBuilder().append(" \"")
-                        .append(entry.getKey())
-                        .append("\": [\"")
-                        .append(entry.getValue().get(0))
-                        .append("\", \"")
-                        .append(entry.getValue().get(1))
-                        .append("\"]")
-                        .toString();
+                    .append(entry.getKey())
+                    .append("\": [\"")
+                    .append(entry.getValue()
+                        .get(0))
+                    .append("\", \"")
+                    .append(entry.getValue()
+                        .get(1))
+                    .append("\"]")
+                    .toString();
                 if (elementCount < dateRanges.size()) {
                     ranges += ",";
                 }
             }
             ranges += "}";
         }
+
+        this.setEnabled(enabled);
         init(this.inputText, language, parentEl, startDate, endDate, minDate, maxDate, showDropdowns, showWeekNumbers, showISOWeekNumbers, singleDatePicker,
              timePicker, timePicker24Hour, timePickerIncrement, timePickerSeconds, dateLimit, autoApply, linkedCalendars, autoUpdateInput, opens, drops,
-             buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern);
+             buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, enabled);
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -27,6 +27,13 @@ public class VDateTimeRangeField extends TextBoxBase {
         this(DOM.createDiv());
     }
 
+    private static int idCounter = 0;
+
+    // use element id to access the textinputfield in JavaScript.
+    private static String getElementId() {
+        return "4711ID" + idCounter++;
+    }
+
     protected VDateTimeRangeField(final Element node) {
         super(node);
         this.inputText = DOM.createInputText();
@@ -35,7 +42,7 @@ public class VDateTimeRangeField extends TextBoxBase {
         com.google.gwt.user.client.Element i = DOM.createElement("i");
         i.addClassName("glyphicon glyphicon-calendar fa fa-calendar");
         getElement().appendChild(i);
-        this.elementId = "4711ID"; // TODO randomize or count up the id;
+        this.elementId = getElementId();
         this.inputText.setId(elementId);
         setStylePrimaryName("bp-datetimerangepicker");
     }
@@ -50,60 +57,59 @@ public class VDateTimeRangeField extends TextBoxBase {
             boolean showDropdowns, boolean showWeekNumbers, boolean showISOWeekNumbers, boolean singleDatePicker, boolean timePicker, boolean timePicker24Hour,
             int timePickerIncrement, boolean timePickerSeconds, String dateLimit, boolean autoApply, boolean linkedCalendars, boolean autoUpdateInput,
             String opens, String drops, String buttonClasses, String applyClass, String cancelClass, String ranges, boolean alwaysShowCalendars,
-            boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean workable) /*-{
-                                                                                                                       var _this = this;
-                                                                                                                       
-                                                                                                                       $wnd.moment.locale(language);
-                                                                                                                       
-                                                                                                                       configString = '{' +
-                                                                                                                       '"showDropdowns": ' + showDropdowns + ',' +
-                                                                                                                       '"showWeekNumbers": ' + showWeekNumbers + ',' +
-                                                                                                                       '"showISOWeekNumbers": ' + showISOWeekNumbers + ',' +
-                                                                                                                       '"singleDatePicker": ' + singleDatePicker + ',' +
-                                                                                                                       '"timePicker": ' + timePicker + ',' +
-                                                                                                                       '"timePicker24Hour": ' + timePicker24Hour + ',' +
-                                                                                                                       '"timePickerIncrement": ' + timePickerIncrement + ',' +
-                                                                                                                       '"timePickerSeconds": ' + timePickerSeconds + ',' +
-                                                                                                                       (typeof(dateLimit) === 'undefined' || dateLimit.length == 0 ? '' : '"dateLimit": ' + dateLimit + ',') +
-                                                                                                                       '"autoApply": ' + autoApply + ',' +
-                                                                                                                       '"linkedCalendars": ' + linkedCalendars + ',' +
-                                                                                                                       '"autoUpdateInput": ' + autoUpdateInput + ',' +
-                                                                                                                       '"opens": "' + opens + '",' +
-                                                                                                                       '"drops": "' + drops + '",' +
-                                                                                                                       '"parentEl": "' + parentEl + '",' +
-                                                                                                                       (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
-                                                                                                                       (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
-                                                                                                                       (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
-                                                                                                                       (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
-                                                                                                                       '"buttonClasses": "' + buttonClasses + '",' +
-                                                                                                                       '"applyClass": "' + applyClass + '",' +
-                                                                                                                       '"cancelClass": "' + cancelClass + '",' +
-                                                                                                                       (typeof(ranges) === 'undefined' || ranges.length == 0 ? '' : '"ranges": ' + ranges + ',') +
-                                                                                                                       '"alwaysShowCalendars": ' + alwaysShowCalendars + ',' +
-                                                                                                                       '"showCustomRangeLabel": ' + showCustomRangeLabel + ',' +
-                                                                                                                       '"locale": { "applyLabel": "' + applyLabel + '",' +
-                                                                                                                       '"cancelLabel": "' + cancelLabel + '"}' + ',' +
-                                                                                                                       '"format": "' + datePattern + '"' +
-                                                                                                                       '}';
-                                                                                                                       
-                                                                                                                       console.log(configString);
-                                                                                                                       
-                                                                                                                       $wnd.$(node).daterangepicker(JSON.parse(configString),
-                                                                                                                       function(start, end, label) {
-                                                                                                                       _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
-                                                                                                                       });
-                                                                                                                       
-                                                                                                                       
-                                                                                                                       
-                                                                                                                       $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
-                                                                                                                          $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
-                                                                                                                       });
-                                                                                                                       
-                                                                                                                       $wnd.alert("Enabled ist: " + workable);
-                                                                                                                       $wnd.$(node).disabled=true;
-                                                                                                                       document.getElementById( "4711ID" ).disabled=true;
-                                                                                                                       
-                                                                                                                       }-*/;
+            boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean workable, String elementId) /*-{
+                                                                                                                                         var _this = this;
+                                                                                                                                         
+                                                                                                                                         $wnd.moment.locale(language);
+                                                                                                                                         
+                                                                                                                                         configString = '{' +
+                                                                                                                                         '"showDropdowns": ' + showDropdowns + ',' +
+                                                                                                                                         '"showWeekNumbers": ' + showWeekNumbers + ',' +
+                                                                                                                                         '"showISOWeekNumbers": ' + showISOWeekNumbers + ',' +
+                                                                                                                                         '"singleDatePicker": ' + singleDatePicker + ',' +
+                                                                                                                                         '"timePicker": ' + timePicker + ',' +
+                                                                                                                                         '"timePicker24Hour": ' + timePicker24Hour + ',' +
+                                                                                                                                         '"timePickerIncrement": ' + timePickerIncrement + ',' +
+                                                                                                                                         '"timePickerSeconds": ' + timePickerSeconds + ',' +
+                                                                                                                                         (typeof(dateLimit) === 'undefined' || dateLimit.length == 0 ? '' : '"dateLimit": ' + dateLimit + ',') +
+                                                                                                                                         '"autoApply": ' + autoApply + ',' +
+                                                                                                                                         '"linkedCalendars": ' + linkedCalendars + ',' +
+                                                                                                                                         '"autoUpdateInput": ' + autoUpdateInput + ',' +
+                                                                                                                                         '"opens": "' + opens + '",' +
+                                                                                                                                         '"drops": "' + drops + '",' +
+                                                                                                                                         '"parentEl": "' + parentEl + '",' +
+                                                                                                                                         (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
+                                                                                                                                         (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
+                                                                                                                                         (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
+                                                                                                                                         (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
+                                                                                                                                         '"buttonClasses": "' + buttonClasses + '",' +
+                                                                                                                                         '"applyClass": "' + applyClass + '",' +
+                                                                                                                                         '"cancelClass": "' + cancelClass + '",' +
+                                                                                                                                         (typeof(ranges) === 'undefined' || ranges.length == 0 ? '' : '"ranges": ' + ranges + ',') +
+                                                                                                                                         '"alwaysShowCalendars": ' + alwaysShowCalendars + ',' +
+                                                                                                                                         '"showCustomRangeLabel": ' + showCustomRangeLabel + ',' +
+                                                                                                                                         '"locale": { "applyLabel": "' + applyLabel + '",' +
+                                                                                                                                         '"cancelLabel": "' + cancelLabel + '"}' + ',' +
+                                                                                                                                         '"format": "' + datePattern + '"' +
+                                                                                                                                         '}';
+                                                                                                                                         
+                                                                                                                                         $wnd.console.log(configString);
+                                                                                                                                         
+                                                                                                                                         $wnd.$(node).daterangepicker(JSON.parse(configString),
+                                                                                                                                         function(start, end, label) {
+                                                                                                                                         _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
+                                                                                                                                         });
+                                                                                                                                         
+                                                                                                                                         
+                                                                                                                                         $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
+                                                                                                                                         $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
+                                                                                                                                         });
+                                                                                                                                         
+                                                                                                                                         // $wnd.alert("Enabled ist: " + workable + "\nwnd: " + $wnd + "\n node: " + $wnd.$(node) + "\nThis" + this + "\nfirstElementChild " + this.firstElementChild + "\nElementId " + elementId + "\ndoc.getElementById(elementId) " + $doc.getElementById(elementId) +  "\ndisabled" +  $doc.getElementById(elementId).disabled);
+                                                                                                                                         $doc.getElementById(elementId).disabled=!workable;
+                                                                                                                                         
+                                                                                                                                         
+                                                                                                                                         }-*/;
 
     private void onUpdateValue(final JsDate start, final JsDate end) {
         this.updateValueHandler.onUpdateValue(start, end);
@@ -159,9 +165,9 @@ public class VDateTimeRangeField extends TextBoxBase {
             ranges += "}";
         }
 
-        this.setEnabled(workable);
         init(this.inputText, language, parentEl, startDate, endDate, minDate, maxDate, showDropdowns, showWeekNumbers, showISOWeekNumbers, singleDatePicker,
              timePicker, timePicker24Hour, timePickerIncrement, timePickerSeconds, dateLimit, autoApply, linkedCalendars, autoUpdateInput, opens, drops,
-             buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, workable);
+             buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, workable,
+             elementId);
     }
 }


### PR DESCRIPTION
From Bonprix-Ticket-System FW-491:

Hi, there are a few bugs in the DateTimeRangeField component. First the width can not be changed neither in pixels nor in percentage, there is again a css style (which comes from d-suite) where the width is hard coded. I suggest that the width should be set to 100% so the text field can be adjusted according to the parent. Also setEnabled() method set to false is not working.
Add functionallity to change date format.

The setEnabled was not implemented. NOTE: The inherited 'enabled' flag from AbstractField.java is not usable (Public var vs. getter and setter etc) so the workable property is introduced. Further on to access the component in javascript I've had no luck with 'this' so I've had to access the component via id.