### PR TITLE
Fw 668 vaadin7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-bootstrap-datetimerangepicker-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.2-SNAPSHOT</version>
+	<version>1.6-SNAPSHOT</version>
 	<name>Bootstrap DateTimeRangePicker Add-on Root Project</name>
 
 	<prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-bootstrap-datetimerangepicker-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.6-SNAPSHOT</version>
+	<version>1.7-SNAPSHOT</version>
 	<name>Bootstrap DateTimeRangePicker Add-on Root Project</name>
 
 	<prerequisites>

--- a/vaadin-bootstrap-datetimerangepicker-demo/pom.xml
+++ b/vaadin-bootstrap-datetimerangepicker-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-bootstrap-datetimerangepicker-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.6-SNAPSHOT</version>
+	<version>1.7-SNAPSHOT</version>
 	<name>Bootstrap DateTimeRangePicker Add-on Demo</name>
 
 	<prerequisites>

--- a/vaadin-bootstrap-datetimerangepicker-demo/pom.xml
+++ b/vaadin-bootstrap-datetimerangepicker-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-bootstrap-datetimerangepicker-demo</artifactId>
 	<packaging>war</packaging>
-	<version>2.2-SNAPSHOT</version>
+	<version>1.6-SNAPSHOT</version>
 	<name>Bootstrap DateTimeRangePicker Add-on Demo</name>
 
 	<prerequisites>
@@ -16,8 +16,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<vaadin.version>8.2.0</vaadin.version>
-		<vaadin.plugin.version>8.2.0</vaadin.plugin.version>
+		<vaadin.version>7.7.0</vaadin.version>
+		<vaadin.plugin.version>7.7.3</vaadin.plugin.version>
 		<jetty.plugin.version>9.3.9.v20160517</jetty.plugin.version>
 	</properties>
 

--- a/vaadin-bootstrap-datetimerangepicker/pom.xml
+++ b/vaadin-bootstrap-datetimerangepicker/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-bootstrap-datetimerangepicker</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2-SNAPSHOT</version>
+	<version>1.6-SNAPSHOT</version>
 	<name>Bootstrap DateTimeRangePicker Add-on</name>
 
 	<prerequisites>
@@ -14,10 +14,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<vaadin.version>8.2.0</vaadin.version>
-		<vaadin.plugin.version>8.2.0</vaadin.plugin.version>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+		<vaadin.version>7.7.3</vaadin.version>
+		<vaadin.plugin.version>7.7.3</vaadin.plugin.version>
 		<gwt.style>DETAILED</gwt.style>
 
 		<!-- ZIP Manifest fields -->

--- a/vaadin-bootstrap-datetimerangepicker/pom.xml
+++ b/vaadin-bootstrap-datetimerangepicker/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>vaadin-bootstrap-datetimerangepicker</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6-SNAPSHOT</version>
+	<version>1.7-SNAPSHOT</version>
 	<name>Bootstrap DateTimeRangePicker Add-on</name>
 
 	<prerequisites>

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
@@ -59,12 +59,6 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         return this.dateTimeRange;
     }
 
-    //    @Override
-    //    protected void doSetValue(final DateTimeRange newValue) {
-    //        this.setDateTimeRange(newValue);
-    //        startDate(newValue.getFrom());
-    //        endDate(newValue.getTo());
-    //    }
 
     @Override
     protected void setInternalValue(final DateTimeRange newValue) {

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
@@ -59,8 +59,16 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         return this.dateTimeRange;
     }
 
+    //    @Override
+    //    protected void doSetValue(final DateTimeRange newValue) {
+    //        this.setDateTimeRange(newValue);
+    //        startDate(newValue.getFrom());
+    //        endDate(newValue.getTo());
+    //    }
+
     @Override
-    protected void doSetValue(final DateTimeRange newValue) {
+    protected void setInternalValue(final DateTimeRange newValue) {
+        super.setInternalValue(newValue);
         this.setDateTimeRange(newValue);
         startDate(newValue.getFrom());
         endDate(newValue.getTo());
@@ -136,6 +144,7 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     }
 
 
+    @Override
     public Class<? extends DateTimeRange> getType() {
         return DateTimeRange.class;
     }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.UUID;
 
 import org.vaadin.addons.datetimerangepicker.client.DateTimeRangeFieldServerRpc;
 import org.vaadin.addons.datetimerangepicker.client.DateTimeRangeFieldState;
@@ -31,7 +32,6 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     private Format dateFormatter = null;
 
     private DateTimeRange dateTimeRange;
-
 
     /**
      * The maximum span between the selected start and end dates. Can have any property you can add to a moment object (i.e. days, months)
@@ -59,15 +59,21 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         return this.dateTimeRange;
     }
 
-
     @Override
     protected void setInternalValue(final DateTimeRange newValue) {
         super.setInternalValue(newValue);
         this.setDateTimeRange(newValue);
-        startDate(newValue.getFrom());
-        endDate(newValue.getTo());
+        if (newValue != null) {
+            getState().setAutoUpdateInput(true);
+            startDate(newValue.getFrom());
+            endDate(newValue.getTo());
+        }
+        else {
+            getState().setAutoUpdateInput(false);
+            startDate(null);
+            endDate(null);
+        }
     }
-
 
     /**
      * Set predefined date ranges the user can select from. Each key is the label for the range, and its value an array with two dates representing the bounds
@@ -96,16 +102,18 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
 
         @Override
         public void valueChanged(final Date from, final Date to) {
-            if (from != null && to != null) {
-                setValue(new DateTimeRange(from, to));
-                DateTimeRangeField.this.dateTimeRange = new DateTimeRange(from, to);
-            }
-            else {
-                DateTimeRangeField.this.dateTimeRange = null;
-            }
+            final DateTimeRange range = new DateTimeRange(from, to);
+            setValue(range);
+            DateTimeRangeField.this.dateTimeRange = range;
+
+        }
+
+        @Override
+        public void valueReseted() {
+            setValue(null);
+            DateTimeRangeField.this.dateTimeRange = null;
         }
     };
-
 
     /**
      * Constructor
@@ -122,11 +130,17 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         registerRpc(this.rpc);
 
         getState().setLanguage(UI.getCurrent()
-                               .getLocale()
-                               .getLanguage());
+            .getLocale()
+            .getLanguage());
         getState().setLinkedCalendars(linkedCalendars);
         getState().setAutoUpdateInput(autoUpdateInput);
         getState().setDatePattern(((SimpleDateFormat) dateFormatter).toPattern());
+        getState().setElementUUID(UUID.randomUUID()
+            .toString());
+
+        if (!autoUpdateInput) {
+            DateTimeRangeField.this.dateTimeRange = null;
+        }
 
         this.dateFormatter = dateFormatter;
     }
@@ -136,7 +150,6 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     protected DateTimeRangeFieldState getState() {
         return (DateTimeRangeFieldState) super.getState();
     }
-
 
     @Override
     public Class<? extends DateTimeRange> getType() {
@@ -189,9 +202,9 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         for (final Entry<String, Range> entry : ranges.entrySet()) {
             final String rangeLabel = entry.getKey();
             final String dateFromAsString = formatDateToString(entry.getValue()
-                                                               .getFrom());
+                .getFrom());
             final String dateToAsString = formatDateToString(entry.getValue()
-                                                             .getTo());
+                .getTo());
 
             final List<String> dateRange = new ArrayList<>();
             dateRange.add(dateFromAsString);

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldClientRpc.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldClientRpc.java
@@ -1,9 +1,0 @@
-package org.vaadin.addons.datetimerangepicker.client;
-
-import com.vaadin.shared.communication.ClientRpc;
-
-// ClientRpc is used to pass events from server to client
-// For sending information about the changes to component state, use State instead
-public interface DateTimeRangeFieldClientRpc extends ClientRpc {
-
-}

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
@@ -46,18 +46,6 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
             }
         });
 
-        //        getWidget().setUpdateValueHandler((start, end) -> {
-        //
-        //            Date startDate = null;
-        //            Date endDate = null;
-        //
-        //            if (start != null && end != null) {
-        //                startDate = new Date((long) start.getTime());
-        //                endDate = new Date((long) end.getTime());
-        //            }
-        //            DateTimeRangeFieldConnector.this.rpc.valueChanged(startDate, endDate);
-        //
-        //        });
     }
 
     // We must implement getWidget() to cast to correct type

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
@@ -3,7 +3,9 @@ package org.vaadin.addons.datetimerangepicker.client;
 import java.util.Date;
 
 import org.vaadin.addons.datetimerangepicker.DateTimeRangeField;
+import org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField.DateRangeFieldClientUpdateValueHandler;
 
+import com.google.gwt.core.client.JsDate;
 import com.vaadin.client.communication.RpcProxy;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractComponentConnector;
@@ -29,18 +31,33 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
             private static final long serialVersionUID = 1L;
         });
 
-        getWidget().setUpdateValueHandler((start, end) -> {
+        getWidget().setUpdateValueHandler(new DateRangeFieldClientUpdateValueHandler() {
 
-            Date startDate = null;
-            Date endDate = null;
+            @Override
+            public void onUpdateValue(final JsDate start, final JsDate end) {
+                Date startDate = null;
+                Date endDate = null;
 
-            if (start != null && end != null) {
-                startDate = new Date((long) start.getTime());
-                endDate = new Date((long) end.getTime());
+                if (start != null && end != null) {
+                    startDate = new Date((long) start.getTime());
+                    endDate = new Date((long) end.getTime());
+                }
+                DateTimeRangeFieldConnector.this.rpc.valueChanged(startDate, endDate);
             }
-            DateTimeRangeFieldConnector.this.rpc.valueChanged(startDate, endDate);
-
         });
+
+        //        getWidget().setUpdateValueHandler((start, end) -> {
+        //
+        //            Date startDate = null;
+        //            Date endDate = null;
+        //
+        //            if (start != null && end != null) {
+        //                startDate = new Date((long) start.getTime());
+        //                endDate = new Date((long) end.getTime());
+        //            }
+        //            DateTimeRangeFieldConnector.this.rpc.valueChanged(startDate, endDate);
+        //
+        //        });
     }
 
     // We must implement getWidget() to cast to correct type

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
@@ -3,9 +3,11 @@ package org.vaadin.addons.datetimerangepicker.client;
 import java.util.Date;
 
 import org.vaadin.addons.datetimerangepicker.DateTimeRangeField;
+import org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField.DateRangeFieldClientResetValueHandler;
 import org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField.DateRangeFieldClientUpdateValueHandler;
 
 import com.google.gwt.core.client.JsDate;
+import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.communication.RpcProxy;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractComponentConnector;
@@ -25,27 +27,24 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
 
     public DateTimeRangeFieldConnector() {
 
-        // To receive RPC events from server, we register ClientRpc
-        // implementation
-        registerRpc(DateTimeRangeFieldClientRpc.class, new DateTimeRangeFieldClientRpc() {
-            private static final long serialVersionUID = 1L;
-        });
-
         getWidget().setUpdateValueHandler(new DateRangeFieldClientUpdateValueHandler() {
 
             @Override
-            public void onUpdateValue(final JsDate start, final JsDate end) {
-                Date startDate = null;
-                Date endDate = null;
-
-                if (start != null && end != null) {
-                    startDate = new Date((long) start.getTime());
-                    endDate = new Date((long) end.getTime());
-                }
-                DateTimeRangeFieldConnector.this.rpc.valueChanged(startDate, endDate);
+            public void onUpdateValue(JsDate start, JsDate end) {
+                DateTimeRangeFieldConnector.this.rpc.valueChanged(new Date((long) start.getTime()), new Date((long) end.getTime()));
             }
+            
         });
+        
+        getWidget().setResetValueHandler(new DateRangeFieldClientResetValueHandler() {
 
+            @Override
+            public void onResetValue() {
+                DateTimeRangeFieldConnector.this.rpc.valueReseted();
+            }
+            
+        });
+        
     }
 
     // We must implement getWidget() to cast to correct type
@@ -75,4 +74,10 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
                             getState().getApplyClass(), getState().getCancelClass(), getState().getDateRanges(), getState().isAlwaysShowCalendars(),
                             getState().isShowCustomRangeLabel(), getState().getDatePattern(), getState().isWorkable());
     }
+
+    @OnStateChange("elementUUID")
+    void updateElementUUID() {
+        getWidget().setElementUUID(getState().getElementUUID());
+    }
+
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldServerRpc.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldServerRpc.java
@@ -9,4 +9,6 @@ public interface DateTimeRangeFieldServerRpc extends ServerRpc {
 
     public void valueChanged(Date from, Date to);
 
+    public void valueReseted();
+
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldState.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldState.java
@@ -63,7 +63,9 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
     private String dateLimitSpanMoment = DateTimeRangeFieldState.EMPTY_STRING;
     private int dateLimitSpanValue = 0;
 
-    private Map<String, List<String>> dateRanges = new HashMap<String, List<String>>();
+    private String elementUUID;
+
+    private Map<String, List<String>> dateRanges = new HashMap<>();
 
     public String getLanguage() {
         return this.language;
@@ -117,7 +119,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.alwaysShowCalendars;
     }
 
-    public void setAlwaysShowCalendars(boolean alwaysShowCalendars) {
+    public void setAlwaysShowCalendars(final boolean alwaysShowCalendars) {
         this.alwaysShowCalendars = alwaysShowCalendars;
     }
 
@@ -125,7 +127,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.showCustomRangeLabel;
     }
 
-    public void setShowCustomRangeLabel(boolean showCustomRangeLabel) {
+    public void setShowCustomRangeLabel(final boolean showCustomRangeLabel) {
         this.showCustomRangeLabel = showCustomRangeLabel;
     }
 
@@ -278,11 +280,11 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.parentEl;
     }
 
-    public void setParentEl(String parentEl) {
+    public void setParentEl(final String parentEl) {
         this.parentEl = parentEl;
     }
 
-    public void setDateLimitSpanMoment(String dateLimitSpanMoment) {
+    public void setDateLimitSpanMoment(final String dateLimitSpanMoment) {
         this.dateLimitSpanMoment = dateLimitSpanMoment;
     }
 
@@ -294,7 +296,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.dateLimitSpanValue;
     }
 
-    public void setDateLimitSpanValue(int dateLimitSpanValue) {
+    public void setDateLimitSpanValue(final int dateLimitSpanValue) {
         this.dateLimitSpanValue = dateLimitSpanValue;
     }
 
@@ -302,7 +304,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.dateRanges;
     }
 
-    public void setDateRanges(Map<String, List<String>> dateRanges) {
+    public void setDateRanges(final Map<String, List<String>> dateRanges) {
         this.dateRanges = dateRanges;
     }
 
@@ -310,16 +312,24 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.datePattern;
     }
 
-    public void setDatePattern(String datePattern) {
+    public void setDatePattern(final String datePattern) {
         this.datePattern = datePattern;
     }
 
     public boolean isWorkable() {
-        return workable;
+        return this.workable;
     }
 
-    public void setWorkable(boolean workable) {
+    public void setWorkable(final boolean workable) {
         this.workable = workable;
+    }
+
+    public String getElementUUID() {
+        return this.elementUUID;
+    }
+
+    public void setElementUUID(final String elementUUID) {
+        this.elementUUID = elementUUID;
     }
 
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -34,6 +34,8 @@ public class VDateTimeRangeField extends TextBoxBase {
         this.inputText = DOM.createInputText();
         this.inputText.addClassName("v-textfield");
         this.inputText.addClassName(VDateTimeRangeField.CLASSNAME);
+        this.inputText.getStyle()
+            .setProperty("width", "100%");
         getElement().appendChild(this.inputText);
         // add Date Select Icon
         final com.google.gwt.user.client.Element i = DOM.createElement("i");
@@ -47,15 +49,15 @@ public class VDateTimeRangeField extends TextBoxBase {
 
         DOM.sinkEvents(resetbutton, Event.ONCLICK);
 
-        Event.setEventListener(resetbutton, new EventListener( ) {
+        Event.setEventListener(resetbutton, new EventListener() {
 
             @Override
-            public void onBrowserEvent(Event event) {
+            public void onBrowserEvent(final Event event) {
                 if (Event.ONCLICK == event.getTypeInt()) {
-                    VDateTimeRangeField. this.resetValueHandler.onResetValue();
+                    VDateTimeRangeField.this.resetValueHandler.onResetValue();
                 }
             }
-            
+
         });
 
         setStylePrimaryName("bp-datetimerangepicker");

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -7,6 +7,8 @@ import com.google.gwt.core.client.JsDate;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.EventListener;
 import com.google.gwt.user.client.ui.TextBoxBase;
 
 // Extend any GWT Widget
@@ -16,24 +18,15 @@ public class VDateTimeRangeField extends TextBoxBase {
     private static final String CLASSNAME = "bp-datetimerangepicker";
 
     private DateRangeFieldClientUpdateValueHandler updateValueHandler;
+    private DateRangeFieldClientResetValueHandler resetValueHandler;
 
-    private final String elementId;
-
-    private final com.google.gwt.user.client.Element inputText;
-
+    private final com.google.gwt.dom.client.Element inputText;
 
     /*
      * Constructor. Ensures that needed html templates are added and injects a <database-visualizer> element to the page.
      */
     public VDateTimeRangeField() {
         this(DOM.createDiv());
-    }
-
-    private static int idCounter = 0;
-
-    // use element id to access the textinputfield in JavaScript.
-    private static String getElementId() {
-        return "4711ID" + VDateTimeRangeField.idCounter++;
     }
 
     protected VDateTimeRangeField(final Element node) {
@@ -51,15 +44,34 @@ public class VDateTimeRangeField extends TextBoxBase {
         final com.google.gwt.user.client.Element resetbutton = DOM.createElement("i");
         resetbutton.addClassName(VDateTimeRangeField.CLASSNAME + "-resetbutton");
         getElement().appendChild(resetbutton);
-        this.elementId = VDateTimeRangeField.getElementId();
-        this.inputText.setId(this.elementId);
+
+        DOM.sinkEvents(resetbutton, Event.ONCLICK);
+
+        Event.setEventListener(resetbutton, new EventListener( ) {
+
+            @Override
+            public void onBrowserEvent(Event event) {
+                if (Event.ONCLICK == event.getTypeInt()) {
+                    VDateTimeRangeField. this.resetValueHandler.onResetValue();
+                }
+            }
+            
+        });
+
         setStylePrimaryName("bp-datetimerangepicker");
+    }
+
+    public void setElementUUID(final String elementUUID) {
+        this.inputText.setId(elementUUID);
     }
 
     public void setUpdateValueHandler(final DateRangeFieldClientUpdateValueHandler updateValueHandler) {
         this.updateValueHandler = updateValueHandler;
     }
 
+    public void setResetValueHandler(final DateRangeFieldClientResetValueHandler resetValueHandler) {
+        this.resetValueHandler = resetValueHandler;
+    }
 
     private native void init(Element node, String language, String parentEl, String startDate, String endDate, String minDate, String maxDate,
             boolean showDropdowns, boolean showWeekNumbers, boolean showISOWeekNumbers, boolean singleDatePicker, boolean timePicker, boolean timePicker24Hour,
@@ -86,8 +98,8 @@ public class VDateTimeRangeField extends TextBoxBase {
                                                                                                                                          '"opens": "' + opens + '",' +
                                                                                                                                          '"drops": "' + drops + '",' +
                                                                                                                                          '"parentEl": "' + parentEl + '",' +
-                                                                                                                                         (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
-                                                                                                                                         (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
+                                                                                                                                         (typeof(startDate) === 'undefined' || startDate.length == 0 ? '' : '"startDate": "' + startDate + '",') +
+                                                                                                                                         (typeof(endDate) === 'undefined' || endDate.length == 0 ? '' : '"endDate": "' + endDate + '",') +
                                                                                                                                          (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
                                                                                                                                          (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
                                                                                                                                          '"buttonClasses": "' + buttonClasses + '",' +
@@ -110,17 +122,10 @@ public class VDateTimeRangeField extends TextBoxBase {
 
 
                                                                                                                                          $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
-                                                                                                                                         $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
+                                                                                                                                             $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
                                                                                                                                          });
-
-
-                                                                                                                                         $wnd.$('.bp-datetimerangepicker-resetbutton').on('click', function(ev, picker) {
-                                                                                                                                             $wnd.$('.bp-datetimerangepicker').val('');
-                                                                                                                                             _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onResetButtonClick()();
-                                                                                                                                         });
-
-
-                                                                                                                                         // $wnd.alert("Enabled ist: " + workable + "\nwnd: " + $wnd + "\n node: " + $wnd.$(node) + "\nThis" + this + "\nfirstElementChild " + this.firstElementChild + "\nElementId " + elementId + "\ndoc.getElementById(elementId) " + $doc.getElementById(elementId) +  "\ndisabled" +  $doc.getElementById(elementId).disabled);
+                                                                                                                                         
+                                                                                                                                         
                                                                                                                                          $doc.getElementById(elementId).disabled=!workable;
 
                                                                                                                                          }-*/;
@@ -129,11 +134,9 @@ public class VDateTimeRangeField extends TextBoxBase {
         this.updateValueHandler.onUpdateValue(start, end);
     }
 
-    private void onResetButtonClick() {
-        this.updateValueHandler.onUpdateValue(null, null);
+    public static interface DateRangeFieldClientResetValueHandler extends EventHandler {
+        void onResetValue();
     }
-
-    // _
 
     public static interface DateRangeFieldClientUpdateValueHandler extends EventHandler {
         void onUpdateValue(JsDate start, JsDate end);
@@ -151,12 +154,12 @@ public class VDateTimeRangeField extends TextBoxBase {
         String dateLimit = "";
         if (dateLimitSpanMoment != null && !dateLimitSpanMoment.equals(VDateTimeRangeField.EMPTY_STRING)) {
             dateLimit = new StringBuilder().append("{ \"")
-                    .append(dateLimitSpanMoment)
+                .append(dateLimitSpanMoment)
 
-                    .append("\": ")
-                    .append(dateLimitSpanValue)
-                    .append(" }")
-                    .toString();
+                .append("\": ")
+                .append(dateLimitSpanValue)
+                .append(" }")
+                .toString();
         }
 
         // Ranges Processing
@@ -167,15 +170,15 @@ public class VDateTimeRangeField extends TextBoxBase {
             for (final Map.Entry<String, List<String>> entry : dateRanges.entrySet()) {
                 elementCount++;
                 ranges += new StringBuilder().append(" \"")
-                        .append(entry.getKey())
-                        .append("\": [\"")
-                        .append(entry.getValue()
-                                .get(0))
-                        .append("\", \"")
-                        .append(entry.getValue()
-                                .get(1))
-                        .append("\"]")
-                        .toString();
+                    .append(entry.getKey())
+                    .append("\": [\"")
+                    .append(entry.getValue()
+                        .get(0))
+                    .append("\", \"")
+                    .append(entry.getValue()
+                        .get(1))
+                    .append("\"]")
+                    .toString();
                 if (elementCount < dateRanges.size()) {
                     ranges += ",";
                 }
@@ -192,6 +195,6 @@ public class VDateTimeRangeField extends TextBoxBase {
         init(this.inputText, language, parentEl, startDate, endDate, minDate, maxDate, showDropdowns, showWeekNumbers, showISOWeekNumbers, singleDatePicker,
              timePicker, timePicker24Hour, timePickerIncrement, timePickerSeconds, dateLimit, autoApply, linkedCalendars, autoUpdateInput, opens, drops,
              buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, workable,
-             this.elementId);
+             this.inputText.getId());
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/js/daterangepicker.js
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/js/daterangepicker.js
@@ -282,25 +282,10 @@
 
         var start, end, range;
 
-        //if no start/end dates set, check if an input element contains initial values
+        //if no start/end dates set, just set value of picket to zero string
         if (typeof options.startDate === 'undefined' && typeof options.endDate === 'undefined') {
             if ($(this.element).is('input[type=text]')) {
-                var val = $(this.element).val(),
-                    split = val.split(this.locale.separator);
-
-                start = end = null;
-
-                if (split.length == 2) {
-                    start = moment(split[0], this.locale.format);
-                    end = moment(split[1], this.locale.format);
-                } else if (this.singleDatePicker && val !== "") {
-                    start = moment(val, this.locale.format);
-                    end = moment(val, this.locale.format);
-                }
-                if (start !== null && end !== null) {
-                    this.setStartDate(start);
-                    this.setEndDate(end);
-                }
+            	$(this.element).val('');
             }
         }
 

--- a/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/public/vaadin-bootstrap-datetimerangepicker/styles.css
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/public/vaadin-bootstrap-datetimerangepicker/styles.css
@@ -3,12 +3,6 @@
 	pointer-events: none;
 }
 
-.bp-datetimerangepicker .v-textfield {
-    padding-right: 35px;
-   /* width: 240px; */
-   width: 100%;
-}
-
 .bp-datetimerangepicker-v-disabled {
 	opacity: 0.5;
 }
@@ -18,16 +12,15 @@
 }
 
 .bp-datetimerangepicker-resetbutton {
-    position: relative;
+    position: absolute;
     display: inline-block;
-    right: -5px;
-    top: 11.5px;
-    margin-right: -20px;
     cursor: pointer;
     width: 16px;
-    height: 24px;
-    background-image: url('resetbutton-default.svg');    
-    background-repeat: no-repeat;    
+    height: 16px;
+    background-image: url(resetbutton-default.svg);
+    background-repeat: no-repeat;
+    margin-left: 6px;
+	margin-top: 4px;
 }
 
 .bp-datetimerangepicker-resetbutton:hover {


### PR DESCRIPTION
Some funtional and optical bugx were fixed:

1) The field has a space above and it's looks distorted

- first issue was space above the widget. This was produced by wrong styling of resetbutton. Bug fixed via changed css styling for reset button

- second issue was the small widgth of widgetset - the whole data range was too long to be seen. This was correctd by setting the widght style to 100% in the widget class

2) When more than 1 date range field is present and clear button is pressed - all date range pickers are cleared. Initially you cannot have empty date range picker aka Exception.

Problem solved by setting autoUpdateInput to false for cases, picker value was reseted (= empty) and true otherwise. Additionally startDate() and endDate() with null value for param must be called in cases, picker is reseted. Additionally some javascript stuff corrected for that: a) in VDateTimeRangeField.init() method, in case of startDate / endDate are undefined OR empty, '' value should be passed and b) in datapicker.js file proper logic corrected.

3) Another problem which is a stopper, after you clear the field (with the X button) in the code it's not empty. -> synchronized client && server side by adding proper onclicked event in the client side

Additionally (is no topic of that ticket), replaced hard coded elementId in the code by UUID && client side rpc class no needed.