### PR TITLE
Fw 668

### DIFF
--- a/vaadin-bootstrap-datetimerangepicker-demo/src/main/java/org/vaadin/addons/datetimerangepicker/DemoUI.java
+++ b/vaadin-bootstrap-datetimerangepicker-demo/src/main/java/org/vaadin/addons/datetimerangepicker/DemoUI.java
@@ -42,11 +42,11 @@ import com.vaadin.ui.VerticalLayout;
 public class DemoUI extends UI {
 
     @WebServlet(
-                value = "/*",
-                asyncSupported = true)
+        value = "/*",
+        asyncSupported = true)
     @VaadinServletConfiguration(
-                                productionMode = false,
-                                ui = DemoUI.class)
+        productionMode = false,
+        ui = DemoUI.class)
     public static class Servlet extends VaadinServlet {
     }
 
@@ -66,30 +66,30 @@ public class DemoUI extends UI {
     // UI Components
 
     // Initialize our new UI component
-    private DateTimeRangeField dateRangeField;
+    private DateTimeRangeField dateRangeFieldPrefilled;
 
-    //    private DateField startDateField;
-    //    private DateField endDateField;
+    private DateTimeRangeField dateRangeFieldEmpty;
+
     private DateField minDateField;
     private DateField maxDateField;
 
     private Date startDate = Date.from(LocalDate.now()
-                                       .minusDays(6)
-                                       .atStartOfDay(ZoneId.systemDefault())
-                                       .toInstant());
+        .minusDays(6)
+        .atStartOfDay(ZoneId.systemDefault())
+        .toInstant());
 
     private Date endDate = Date.from(LocalDate.now()
-                                     .atStartOfDay(ZoneId.systemDefault())
-                                     .toInstant());
+        .atStartOfDay(ZoneId.systemDefault())
+        .toInstant());
 
     private final Date today = Date.from(LocalDate.now()
-                                         .atStartOfDay(ZoneId.systemDefault())
-                                         .toInstant());
+        .atStartOfDay(ZoneId.systemDefault())
+        .toInstant());
 
     private final Date yesterday = Date.from(LocalDate.now()
-                                             .minusDays(1)
-                                             .atStartOfDay(ZoneId.systemDefault())
-                                             .toInstant());
+        .minusDays(1)
+        .atStartOfDay(ZoneId.systemDefault())
+        .toInstant());
 
     private ComboBox comboOpens;
     private ComboBox comboDrops;
@@ -109,7 +109,6 @@ public class DemoUI extends UI {
     private CheckBox checkDateLimit;
     private CheckBox checkAutoApply;
     private CheckBox checkLinkedCalendars;
-    private CheckBox checkAutoUpdateInput;
     private CheckBox checkEnabled;
 
     private TextField textButtonClasses;
@@ -130,38 +129,57 @@ public class DemoUI extends UI {
 
         // Initialize our new UI component
         final boolean linkedCalendars = true;
-        final boolean autoUpdateInput = true;
         setLocale(DemoUI.LOCALE_DEFAULT);
         final Format dateFormatter = DateFormat.getDateInstance(DateFormat.SHORT, DemoUI.LOCALE_DEFAULT);
-        this.dateRangeField = new DateTimeRangeField(dateFormatter, linkedCalendars, autoUpdateInput).language(getLocale().toString());
-        this.dateRangeField.setWidth("300px");
+        this.dateRangeFieldPrefilled = new DateTimeRangeField(dateFormatter, linkedCalendars, true).language(getLocale().toString());
+        this.dateRangeFieldPrefilled.setWidth("300px");
 
-        final Binder<DateTimeRangeBean> binder = new Binder<>(DateTimeRangeBean.class);
-        binder.bind(this.dateRangeField, DateTimeRangeBean::getDateTimeRange, DateTimeRangeBean::setDateTimeRange);
+        final Binder<DateTimeRangeBean> binderPrefilled = new Binder<>(DateTimeRangeBean.class);
+        binderPrefilled.bind(this.dateRangeFieldPrefilled, DateTimeRangeBean::getDateTimeRange, DateTimeRangeBean::setDateTimeRange);
 
-        final DateTimeRangeBean bean = new DateTimeRangeBean(new DateTimeRange(this.startDate, this.endDate));
-        binder.setBean(bean);
+        final DateTimeRangeBean beanPrefilled = new DateTimeRangeBean(new DateTimeRange(this.startDate, this.endDate));
+        binderPrefilled.setBean(beanPrefilled);
 
-        this.dateRangeField.addValueChangeListener(e -> {
+        this.dateRangeFieldEmpty = new DateTimeRangeField(dateFormatter, linkedCalendars, false).language(getLocale().toString());
+        this.dateRangeFieldEmpty.setWidth("300px");
+        final Binder<DateTimeRangeBean> binderEmpty = new Binder<>(DateTimeRangeBean.class);
+        binderEmpty.bind(this.dateRangeFieldEmpty, DateTimeRangeBean::getDateTimeRange, DateTimeRangeBean::setDateTimeRange);
+        final DateTimeRangeBean beanEmpty = new DateTimeRangeBean(null);
+        binderEmpty.setBean(beanEmpty);
+
+        final Button buttonEmpty = new Button("Show value");
+        buttonEmpty.addClickListener(event -> {
+            if (this.dateRangeFieldEmpty.getValue() != null) {
+                beanEmpty.setDateTimeRange(this.dateRangeFieldEmpty.getValue());
+                Notification.show(binderEmpty.getBean()
+                    .getDateTimeRange()
+                    .toString());
+            }
+            else {
+                Notification.show("No DateRage is selected!");
+            }
+
+        });
+
+        this.dateRangeFieldPrefilled.addValueChangeListener(e -> {
             final DateTimeRangeField dateTimeRangeField = (DateTimeRangeField) e.getSource();
-            if (dateTimeRangeField != null && dateTimeRangeField.getDateTimeRange().getFrom() != null) {
-                this.startDate = dateTimeRangeField.getDateTimeRange().getFrom();
-                this.endDate = dateTimeRangeField.getDateTimeRange().getTo();
-                bean.setDateTimeRange(new DateTimeRange(this.startDate, this.endDate));
+            if (dateTimeRangeField != null && dateTimeRangeField.getDateTimeRange() != null) {
+                this.startDate = dateTimeRangeField.getDateTimeRange()
+                    .getFrom();
+                this.endDate = dateTimeRangeField.getDateTimeRange()
+                    .getTo();
+                beanEmpty.setDateTimeRange(new DateTimeRange(this.startDate, this.endDate));
             }
         });
 
         final ValueChangeListener valueChangeListener = event -> {
-            binder.removeBinding(DemoUI.this.dateRangeField);
+            binderPrefilled.removeBinding(DemoUI.this.dateRangeFieldPrefilled);
             setLocale(new Locale(this.cbLanguage.getValue()
-                                 .toString()));
+                .toString()));
 
-            //            this.startDateField.setEnabled(this.checkEnabled.getValue());
-            //            this.startDateField.setLocale(getLocale());
-            //            this.endDateField.setLocale(getLocale());
             this.minDateField.setLocale(getLocale());
             this.maxDateField.setLocale(getLocale());
-            this.dateRangeField.setLocale(getLocale());
+            this.dateRangeFieldPrefilled.setLocale(getLocale());
 
             DateTimeRangeField.DateLimit dateLimit = null;
             if (DemoUI.this.checkDateLimit.getValue()) {
@@ -178,58 +196,45 @@ public class DemoUI extends UI {
             }
 
             // Others
-            DemoUI.this.dateRangeField.parentEl(DemoUI.this.textParentEl.getValue())
-            .minDate(asDate(DemoUI.this.minDateField.getValue()))
-            .maxDate(asDate(DemoUI.this.maxDateField.getValue()))
-            .applyLabel(DemoUI.this.textApplyLabel.getValue())
-            .cancelLabel(DemoUI.this.textCancelLabel.getValue())
-            .opens(DateTimeRangeEnums.OPENS.valueOf(DemoUI.this.comboOpens.getValue()
-                                                    .toString()
-                                                    .toUpperCase()))
-            .language(DemoUI.this.cbLanguage.getValue()
-                      .toString())
-            .drops(DateTimeRangeEnums.DROPS.valueOf(DemoUI.this.comboDrops.getValue()
-                                                    .toString()
-                                                    .toUpperCase()))
-            .showDropdowns(DemoUI.this.checkShowDropDowns.getValue())
-            .showWeekNumbers(DemoUI.this.checkShowWeekNumbers.getValue())
-            .showISOWeekNumbers(DemoUI.this.checkShowISOWeekNumbers.getValue())
-            .singleDatePicker(DemoUI.this.checkSingleDatePicker.getValue())
-            .timePicker(DemoUI.this.checkTimePicker.getValue())
-            .timePicker24Hour(DemoUI.this.checkTimePicker24Hour.getValue())
-            .timePickerIncrement(Integer.valueOf(DemoUI.this.textTimePickerIncrement.getValue()))
-            .timePickerSeconds(DemoUI.this.checkTimePickerSeconds.getValue())
-            .dateLimit(dateLimit)
-            .autoApply(DemoUI.this.checkAutoApply.getValue())
-            .linkedCalendars(DemoUI.this.checkLinkedCalendars.getValue())
-            .autoUpdateInput(DemoUI.this.checkAutoUpdateInput.getValue())
-            .buttonClasses(DemoUI.this.textButtonClasses.getValue())
-            .applyClass(DemoUI.this.textApplyClass.getValue())
-            .cancelClass(DemoUI.this.textCancelClass.getValue())
-            .ranges(ranges)
-            .workable(DemoUI.this.checkEnabled.getValue())
-            .alwaysShowCalendars(DemoUI.this.checkAlwaysShowCalendars.getValue())
-            .showCustomRangeLabel(DemoUI.this.checkShowCustomRangeLabel.getValue());
+            DemoUI.this.dateRangeFieldPrefilled.parentEl(DemoUI.this.textParentEl.getValue())
+                .minDate(asDate(DemoUI.this.minDateField.getValue()))
+                .maxDate(asDate(DemoUI.this.maxDateField.getValue()))
+                .applyLabel(DemoUI.this.textApplyLabel.getValue())
+                .cancelLabel(DemoUI.this.textCancelLabel.getValue())
+                .opens(DateTimeRangeEnums.OPENS.valueOf(DemoUI.this.comboOpens.getValue()
+                    .toString()
+                    .toUpperCase()))
+                .language(DemoUI.this.cbLanguage.getValue()
+                    .toString())
+                .drops(DateTimeRangeEnums.DROPS.valueOf(DemoUI.this.comboDrops.getValue()
+                    .toString()
+                    .toUpperCase()))
+                .showDropdowns(DemoUI.this.checkShowDropDowns.getValue())
+                .showWeekNumbers(DemoUI.this.checkShowWeekNumbers.getValue())
+                .showISOWeekNumbers(DemoUI.this.checkShowISOWeekNumbers.getValue())
+                .singleDatePicker(DemoUI.this.checkSingleDatePicker.getValue())
+                .timePicker(DemoUI.this.checkTimePicker.getValue())
+                .timePicker24Hour(DemoUI.this.checkTimePicker24Hour.getValue())
+                .timePickerIncrement(Integer.valueOf(DemoUI.this.textTimePickerIncrement.getValue()))
+                .timePickerSeconds(DemoUI.this.checkTimePickerSeconds.getValue())
+                .dateLimit(dateLimit)
+                .autoApply(DemoUI.this.checkAutoApply.getValue())
+                .linkedCalendars(DemoUI.this.checkLinkedCalendars.getValue())
+                .buttonClasses(DemoUI.this.textButtonClasses.getValue())
+                .applyClass(DemoUI.this.textApplyClass.getValue())
+                .cancelClass(DemoUI.this.textCancelClass.getValue())
+                .ranges(ranges)
+                .workable(DemoUI.this.checkEnabled.getValue())
+                .alwaysShowCalendars(DemoUI.this.checkAlwaysShowCalendars.getValue())
+                .showCustomRangeLabel(DemoUI.this.checkShowCustomRangeLabel.getValue());
 
-            bean.setDateTimeRange(new DateTimeRange(this.startDate, this.endDate));
-            binder.bind(this.dateRangeField, DateTimeRangeBean::getDateTimeRange, DateTimeRangeBean::setDateTimeRange);
+            beanEmpty.setDateTimeRange(new DateTimeRange(this.startDate, this.endDate));
+            binderPrefilled.bind(this.dateRangeFieldPrefilled, DateTimeRangeBean::getDateTimeRange, DateTimeRangeBean::setDateTimeRange);
         };
 
         // ParentEl
         this.textParentEl = new TextField("parentEl");
         this.textParentEl.addValueChangeListener(valueChangeListener);
-
-        // StartDate
-        //        this.startDateField = new DateField("startDate");
-        //        this.startDateField.setLocale(getLocale());
-        //        this.startDateField.setValue(asLocalDate(this.startDate));
-        //        this.startDateField.addValueChangeListener(valueChangeListener);
-        //
-        //        // EndDate
-        //        this.endDateField = new DateField("endDate");
-        //        this.endDateField.setLocale(getLocale());
-        //        this.endDateField.setValue(asLocalDate(this.endDate));
-        //        this.endDateField.addValueChangeListener(valueChangeListener);
 
         // MinDate
         this.minDateField = new DateField("minDate");
@@ -309,11 +314,6 @@ public class DemoUI extends UI {
         this.checkLinkedCalendars.setValue(true);
         this.checkLinkedCalendars.addValueChangeListener(valueChangeListener);
 
-        // Checkbox autoUpdateInput
-        this.checkAutoUpdateInput = new CheckBox("autoUpdateInput");
-        this.checkAutoUpdateInput.setValue(true);
-        this.checkAutoUpdateInput.addValueChangeListener(valueChangeListener);
-
         // Checkbox enabled
         this.checkEnabled = new CheckBox("enabled");
         this.checkEnabled.setValue(true);
@@ -368,23 +368,23 @@ public class DemoUI extends UI {
         this.cbLanguage.addValueChangeListener(valueChangeListener);
 
         // Button show
-        final Button button = new Button("Show value");
-        button.addClickListener(event -> {
-            if (this.dateRangeField.getValue() != null) {
-                bean.setDateTimeRange(this.dateRangeField.getValue());
-                Notification.show(binder.getBean().getDateTimeRange().toString());
-            } else {
+        final Button buttonPrefilled = new Button("Show value");
+        buttonPrefilled.addClickListener(event -> {
+            if (this.dateRangeFieldPrefilled.getValue() != null) {
+                beanPrefilled.setDateTimeRange(this.dateRangeFieldPrefilled.getValue());
+                Notification.show(binderPrefilled.getBean()
+                    .getDateTimeRange()
+                    .toString());
+            }
+            else {
                 Notification.show("No DateRage is selected!");
             }
 
         });
 
-
         final VerticalLayout leftLayout = new VerticalLayout();
         leftLayout.setSpacing(true);
         leftLayout.addComponent(this.textParentEl);
-        //        leftLayout.addComponent(this.startDateField);
-        //        leftLayout.addComponent(this.endDateField);
         leftLayout.addComponent(this.minDateField);
         leftLayout.addComponent(this.maxDateField);
         leftLayout.addComponent(this.comboOpens);
@@ -404,7 +404,6 @@ public class DemoUI extends UI {
         middleLayout.addComponent(this.checkDateLimit);
         middleLayout.addComponent(this.checkAutoApply);
         middleLayout.addComponent(this.checkLinkedCalendars);
-        middleLayout.addComponent(this.checkAutoUpdateInput);
         middleLayout.addComponent(this.checkEnabled);
 
         final VerticalLayout rightLayout = new VerticalLayout();
@@ -426,21 +425,29 @@ public class DemoUI extends UI {
         settingsLayout.addComponent(middleLayout);
         settingsLayout.addComponent(rightLayout);
 
-        final VerticalLayout componentLayout = new VerticalLayout();
-        componentLayout.setCaption("DateTimeRangeField");
-        componentLayout.setSpacing(true);
-        componentLayout.setMargin(true);
-        componentLayout.addComponent(this.dateRangeField);
-        componentLayout.addComponent(button);
+        final VerticalLayout componentLayoutPrefilled = new VerticalLayout();
+        componentLayoutPrefilled.setCaption("DateTimeRangeField with prefilled initial value");
+        componentLayoutPrefilled.setSpacing(true);
+        componentLayoutPrefilled.setMargin(true);
+        componentLayoutPrefilled.addComponent(this.dateRangeFieldPrefilled);
+        componentLayoutPrefilled.addComponent(buttonPrefilled);
+        componentLayoutPrefilled.addComponent(settingsLayout);
 
-        final VerticalLayout mainLayout = new VerticalLayout();
+        final VerticalLayout componentLayoutEmpty = new VerticalLayout();
+        componentLayoutEmpty.setCaption("DateTimeRangeField with empty initial value");
+        componentLayoutEmpty.setSpacing(true);
+        componentLayoutEmpty.setMargin(true);
+        componentLayoutEmpty.addComponent(this.dateRangeFieldEmpty);
+        componentLayoutEmpty.addComponent(buttonEmpty);
+
+        final HorizontalLayout mainLayout = new HorizontalLayout();
         mainLayout.setStyleName("demoContentLayout");
         mainLayout.setSizeFull();
         mainLayout.setMargin(true);
-        mainLayout.addComponent(componentLayout);
-        mainLayout.addComponent(settingsLayout);
-        mainLayout.setExpandRatio(componentLayout, 0.2f);
-        mainLayout.setExpandRatio(settingsLayout, 0.8f);
+        mainLayout.addComponent(componentLayoutPrefilled);
+        mainLayout.addComponent(componentLayoutEmpty);
+        mainLayout.setExpandRatio(componentLayoutPrefilled, 0.8f);
+        mainLayout.setExpandRatio(componentLayoutEmpty, 0.2f);
 
         setContent(mainLayout);
     }
@@ -453,7 +460,7 @@ public class DemoUI extends UI {
      * @return {@link DateTimeRangeField.DateLimit}
      */
     private DateTimeRangeField.DateLimit buildDateLimit(final String dateLimitSpanMoment, final int dateLimitSpanValue) {
-        final DateTimeRangeField.DateLimit dateLimit = DemoUI.this.dateRangeField.new DateLimit(dateLimitSpanMoment, dateLimitSpanValue);
+        final DateTimeRangeField.DateLimit dateLimit = DemoUI.this.dateRangeFieldPrefilled.new DateLimit(dateLimitSpanMoment, dateLimitSpanValue);
         return dateLimit;
     }
 
@@ -466,18 +473,21 @@ public class DemoUI extends UI {
      * @return {@link DateTimeRangeField.Range}
      */
     private DateTimeRangeField.Range buildRange(final Date from, final Date to) {
-        final DateTimeRangeField.Range range = DemoUI.this.dateRangeField.new Range(from, to);
+        final DateTimeRangeField.Range range = DemoUI.this.dateRangeFieldPrefilled.new Range(from, to);
         return range;
     }
 
-
     // Transform LocalDate to Date
     private Date asDate(final LocalDate localDate) {
-        return (localDate != null) ? Date.from(localDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()) : null;
+        return (localDate != null) ? Date.from(localDate.atStartOfDay()
+            .atZone(ZoneId.systemDefault())
+            .toInstant()) : null;
     }
 
     // Transform Date to LocalDate
     private LocalDate asLocalDate(final Date date) {
-        return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+        return Instant.ofEpochMilli(date.getTime())
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate();
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/DateTimeRangeField.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.UUID;
 
 import org.vaadin.addons.datetimerangepicker.client.DateTimeRangeFieldServerRpc;
 import org.vaadin.addons.datetimerangepicker.client.DateTimeRangeFieldState;
@@ -31,7 +32,6 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     private Format dateFormatter = null;
 
     private DateTimeRange dateTimeRange;
-
 
     /**
      * The maximum span between the selected start and end dates. Can have any property you can add to a moment object (i.e. days, months)
@@ -62,10 +62,17 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     @Override
     protected void doSetValue(final DateTimeRange newValue) {
         this.setDateTimeRange(newValue);
-        startDate(newValue.getFrom());
-        endDate(newValue.getTo());
+        if (newValue != null) {
+            getState().setAutoUpdateInput(true);
+            startDate(newValue.getFrom());
+            endDate(newValue.getTo());
+        }
+        else {
+            getState().setAutoUpdateInput(false);
+            startDate(null);
+            endDate(null);
+        }
     }
-
 
     /**
      * Set predefined date ranges the user can select from. Each key is the label for the range, and its value an array with two dates representing the bounds
@@ -94,16 +101,18 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
 
         @Override
         public void valueChanged(final Date from, final Date to) {
-            if (from != null && to != null) {
-                setValue(new DateTimeRange(from, to));
-                DateTimeRangeField.this.dateTimeRange = new DateTimeRange(from, to);
-            }
-            else {
-                DateTimeRangeField.this.dateTimeRange = null;
-            }
+            final DateTimeRange range = new DateTimeRange(from, to);
+            setValue(range);
+            DateTimeRangeField.this.dateTimeRange = range;
+
+        }
+
+        @Override
+        public void valueReseted() {
+            setValue(null);
+            DateTimeRangeField.this.dateTimeRange = null;
         }
     };
-
 
     /**
      * Constructor
@@ -120,11 +129,17 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         registerRpc(this.rpc);
 
         getState().setLanguage(UI.getCurrent()
-                               .getLocale()
-                               .getLanguage());
+            .getLocale()
+            .getLanguage());
         getState().setLinkedCalendars(linkedCalendars);
         getState().setAutoUpdateInput(autoUpdateInput);
         getState().setDatePattern(((SimpleDateFormat) dateFormatter).toPattern());
+        getState().setElementUUID(UUID.randomUUID()
+            .toString());
+
+        if (!autoUpdateInput) {
+            DateTimeRangeField.this.dateTimeRange = null;
+        }
 
         this.dateFormatter = dateFormatter;
     }
@@ -134,7 +149,6 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
     protected DateTimeRangeFieldState getState() {
         return (DateTimeRangeFieldState) super.getState();
     }
-
 
     public Class<? extends DateTimeRange> getType() {
         return DateTimeRange.class;
@@ -186,9 +200,9 @@ public class DateTimeRangeField extends AbstractField<DateTimeRange> {
         for (final Entry<String, Range> entry : ranges.entrySet()) {
             final String rangeLabel = entry.getKey();
             final String dateFromAsString = formatDateToString(entry.getValue()
-                                                               .getFrom());
+                .getFrom());
             final String dateToAsString = formatDateToString(entry.getValue()
-                                                             .getTo());
+                .getTo());
 
             final List<String> dateRange = new ArrayList<>();
             dateRange.add(dateFromAsString);

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldClientRpc.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldClientRpc.java
@@ -1,9 +1,0 @@
-package org.vaadin.addons.datetimerangepicker.client;
-
-import com.vaadin.shared.communication.ClientRpc;
-
-// ClientRpc is used to pass events from server to client
-// For sending information about the changes to component state, use State instead
-public interface DateTimeRangeFieldClientRpc extends ClientRpc {
-
-}

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldConnector.java
@@ -4,6 +4,7 @@ import java.util.Date;
 
 import org.vaadin.addons.datetimerangepicker.DateTimeRangeField;
 
+import com.vaadin.client.annotations.OnStateChange;
 import com.vaadin.client.communication.RpcProxy;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractComponentConnector;
@@ -23,24 +24,11 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
 
     public DateTimeRangeFieldConnector() {
 
-        // To receive RPC events from server, we register ClientRpc
-        // implementation
-        registerRpc(DateTimeRangeFieldClientRpc.class, new DateTimeRangeFieldClientRpc() {
-            private static final long serialVersionUID = 1L;
-        });
-
         getWidget().setUpdateValueHandler((start, end) -> {
-
-            Date startDate = null;
-            Date endDate = null;
-
-            if (start != null && end != null) {
-                startDate = new Date((long) start.getTime());
-                endDate = new Date((long) end.getTime());
-            }
-            DateTimeRangeFieldConnector.this.rpc.valueChanged(startDate, endDate);
-
+            DateTimeRangeFieldConnector.this.rpc.valueChanged(new Date((long) start.getTime()), new Date((long) end.getTime()));
         });
+
+        getWidget().setResetValueHandler(() -> DateTimeRangeFieldConnector.this.rpc.valueReseted());
     }
 
     // We must implement getWidget() to cast to correct type
@@ -70,4 +58,10 @@ public class DateTimeRangeFieldConnector extends AbstractComponentConnector {
                             getState().getApplyClass(), getState().getCancelClass(), getState().getDateRanges(), getState().isAlwaysShowCalendars(),
                             getState().isShowCustomRangeLabel(), getState().getDatePattern(), getState().isWorkable());
     }
+
+    @OnStateChange("elementUUID")
+    void updateElementUUID() {
+        getWidget().setElementUUID(getState().getElementUUID());
+    }
+
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldServerRpc.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldServerRpc.java
@@ -9,4 +9,6 @@ public interface DateTimeRangeFieldServerRpc extends ServerRpc {
 
     public void valueChanged(Date from, Date to);
 
+    public void valueReseted();
+
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldState.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/DateTimeRangeFieldState.java
@@ -63,7 +63,9 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
     private String dateLimitSpanMoment = DateTimeRangeFieldState.EMPTY_STRING;
     private int dateLimitSpanValue = 0;
 
-    private Map<String, List<String>> dateRanges = new HashMap<String, List<String>>();
+    private String elementUUID;
+
+    private Map<String, List<String>> dateRanges = new HashMap<>();
 
     public String getLanguage() {
         return this.language;
@@ -117,7 +119,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.alwaysShowCalendars;
     }
 
-    public void setAlwaysShowCalendars(boolean alwaysShowCalendars) {
+    public void setAlwaysShowCalendars(final boolean alwaysShowCalendars) {
         this.alwaysShowCalendars = alwaysShowCalendars;
     }
 
@@ -125,7 +127,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.showCustomRangeLabel;
     }
 
-    public void setShowCustomRangeLabel(boolean showCustomRangeLabel) {
+    public void setShowCustomRangeLabel(final boolean showCustomRangeLabel) {
         this.showCustomRangeLabel = showCustomRangeLabel;
     }
 
@@ -278,11 +280,11 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.parentEl;
     }
 
-    public void setParentEl(String parentEl) {
+    public void setParentEl(final String parentEl) {
         this.parentEl = parentEl;
     }
 
-    public void setDateLimitSpanMoment(String dateLimitSpanMoment) {
+    public void setDateLimitSpanMoment(final String dateLimitSpanMoment) {
         this.dateLimitSpanMoment = dateLimitSpanMoment;
     }
 
@@ -294,7 +296,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.dateLimitSpanValue;
     }
 
-    public void setDateLimitSpanValue(int dateLimitSpanValue) {
+    public void setDateLimitSpanValue(final int dateLimitSpanValue) {
         this.dateLimitSpanValue = dateLimitSpanValue;
     }
 
@@ -302,7 +304,7 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.dateRanges;
     }
 
-    public void setDateRanges(Map<String, List<String>> dateRanges) {
+    public void setDateRanges(final Map<String, List<String>> dateRanges) {
         this.dateRanges = dateRanges;
     }
 
@@ -310,16 +312,24 @@ public class DateTimeRangeFieldState extends AbstractFieldState {
         return this.datePattern;
     }
 
-    public void setDatePattern(String datePattern) {
+    public void setDatePattern(final String datePattern) {
         this.datePattern = datePattern;
     }
 
     public boolean isWorkable() {
-        return workable;
+        return this.workable;
     }
 
-    public void setWorkable(boolean workable) {
+    public void setWorkable(final boolean workable) {
         this.workable = workable;
+    }
+
+    public String getElementUUID() {
+        return this.elementUUID;
+    }
+
+    public void setElementUUID(final String elementUUID) {
+        this.elementUUID = elementUUID;
     }
 
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -34,6 +34,8 @@ public class VDateTimeRangeField extends TextBoxBase {
         this.inputText.addClassName("v-textfield");
         this.inputText.addClassName(VDateTimeRangeField.CLASSNAME);
         getElement().appendChild(this.inputText);
+        this.inputText.getStyle()
+            .setProperty("width", "100%");
         // add Date Select Icon
         final com.google.gwt.user.client.Element i = DOM.createElement("i");
         i.addClassName("glyphicon glyphicon-calendar fa fa-calendar");
@@ -73,9 +75,9 @@ public class VDateTimeRangeField extends TextBoxBase {
             String opens, String drops, String buttonClasses, String applyClass, String cancelClass, String ranges, boolean alwaysShowCalendars,
             boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean workable, String elementId) /*-{
                                                                                                                                          var _this = this;
-                                                                                                                                         
+
                                                                                                                                          $wnd.moment.locale(language);
-                                                                                                                                         
+
                                                                                                                                           configString = '{' +
                                                                                                                                          '"showDropdowns": ' + showDropdowns + ',' +
                                                                                                                                          '"showWeekNumbers": ' + showWeekNumbers + ',' +
@@ -106,22 +108,22 @@ public class VDateTimeRangeField extends TextBoxBase {
                                                                                                                                          '"cancelLabel": "' + cancelLabel + '"}' + ',' +
                                                                                                                                          '"format": "' + datePattern + '"' +
                                                                                                                                          '}';
-                                                                                                                                         
+
                                                                                                                                          $wnd.console.log(configString);
-                                                                                                                                         
+
                                                                                                                                          $wnd.$(node).daterangepicker(JSON.parse(configString),
                                                                                                                                          function(start, end, label) {
                                                                                                                                          _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
                                                                                                                                          });
-                                                                                                                                         
-                                                                                                                                         
+
+
                                                                                                                                          $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
                                                                                                                                              $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
                                                                                                                                          });
-
-
-                                                                                                                                         $doc.getElementById(elementId).disabled=!workable;
                                                                                                                                          
+                                                                                                                                         
+                                                                                                                                         $doc.getElementById(elementId).disabled=!workable;
+
                                                                                                                                          }-*/;
 
     private void onUpdateValue(final JsDate start, final JsDate end) {

--- a/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/java/org/vaadin/addons/datetimerangepicker/client/VDateTimeRangeField.java
@@ -7,6 +7,7 @@ import com.google.gwt.core.client.JsDate;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.TextBoxBase;
 
 // Extend any GWT Widget
@@ -16,24 +17,15 @@ public class VDateTimeRangeField extends TextBoxBase {
     private static final String CLASSNAME = "bp-datetimerangepicker";
 
     private DateRangeFieldClientUpdateValueHandler updateValueHandler;
+    private DateRangeFieldClientResetValueHandler resetValueHandler;
 
-    private final String elementId;
-
-    private final com.google.gwt.user.client.Element inputText;
-
+    private final com.google.gwt.dom.client.Element inputText;
 
     /*
      * Constructor. Ensures that needed html templates are added and injects a <database-visualizer> element to the page.
      */
     public VDateTimeRangeField() {
         this(DOM.createDiv());
-    }
-
-    private static int idCounter = 0;
-
-    // use element id to access the textinputfield in JavaScript.
-    private static String getElementId() {
-        return "4711ID" + VDateTimeRangeField.idCounter++;
     }
 
     protected VDateTimeRangeField(final Element node) {
@@ -51,15 +43,29 @@ public class VDateTimeRangeField extends TextBoxBase {
         final com.google.gwt.user.client.Element resetbutton = DOM.createElement("i");
         resetbutton.addClassName(VDateTimeRangeField.CLASSNAME + "-resetbutton");
         getElement().appendChild(resetbutton);
-        this.elementId = VDateTimeRangeField.getElementId();
-        this.inputText.setId(this.elementId);
+
+        DOM.sinkEvents(resetbutton, Event.ONCLICK);
+
+        Event.setEventListener(resetbutton, event -> {
+            if (Event.ONCLICK == event.getTypeInt()) {
+                this.resetValueHandler.onResetValue();
+            }
+        });
+
         setStylePrimaryName("bp-datetimerangepicker");
+    }
+
+    public void setElementUUID(final String elementUUID) {
+        this.inputText.setId(elementUUID);
     }
 
     public void setUpdateValueHandler(final DateRangeFieldClientUpdateValueHandler updateValueHandler) {
         this.updateValueHandler = updateValueHandler;
     }
 
+    public void setResetValueHandler(final DateRangeFieldClientResetValueHandler resetValueHandler) {
+        this.resetValueHandler = resetValueHandler;
+    }
 
     private native void init(Element node, String language, String parentEl, String startDate, String endDate, String minDate, String maxDate,
             boolean showDropdowns, boolean showWeekNumbers, boolean showISOWeekNumbers, boolean singleDatePicker, boolean timePicker, boolean timePicker24Hour,
@@ -67,9 +73,9 @@ public class VDateTimeRangeField extends TextBoxBase {
             String opens, String drops, String buttonClasses, String applyClass, String cancelClass, String ranges, boolean alwaysShowCalendars,
             boolean showCustomRangeLabel, String applyLabel, String cancelLabel, String datePattern, boolean workable, String elementId) /*-{
                                                                                                                                          var _this = this;
-
+                                                                                                                                         
                                                                                                                                          $wnd.moment.locale(language);
-
+                                                                                                                                         
                                                                                                                                           configString = '{' +
                                                                                                                                          '"showDropdowns": ' + showDropdowns + ',' +
                                                                                                                                          '"showWeekNumbers": ' + showWeekNumbers + ',' +
@@ -86,8 +92,8 @@ public class VDateTimeRangeField extends TextBoxBase {
                                                                                                                                          '"opens": "' + opens + '",' +
                                                                                                                                          '"drops": "' + drops + '",' +
                                                                                                                                          '"parentEl": "' + parentEl + '",' +
-                                                                                                                                         (typeof(startDate) === 'undefined' ? '' : '"startDate": "' + startDate + '",') +
-                                                                                                                                         (typeof(endDate) === 'undefined' ? '' : '"endDate": "' + endDate + '",') +
+                                                                                                                                         (typeof(startDate) === 'undefined' || startDate.length == 0 ? '' : '"startDate": "' + startDate + '",') +
+                                                                                                                                         (typeof(endDate) === 'undefined' || endDate.length == 0 ? '' : '"endDate": "' + endDate + '",') +
                                                                                                                                          (typeof(minDate) === 'undefined' || minDate.length == 0 ? '' : '"minDate": "' + minDate + '",') +
                                                                                                                                          (typeof(maxDate) === 'undefined' || maxDate.length == 0 ? '' : '"maxDate": "' + maxDate + '",') +
                                                                                                                                          '"buttonClasses": "' + buttonClasses + '",' +
@@ -100,40 +106,31 @@ public class VDateTimeRangeField extends TextBoxBase {
                                                                                                                                          '"cancelLabel": "' + cancelLabel + '"}' + ',' +
                                                                                                                                          '"format": "' + datePattern + '"' +
                                                                                                                                          '}';
-
+                                                                                                                                         
                                                                                                                                          $wnd.console.log(configString);
-
+                                                                                                                                         
                                                                                                                                          $wnd.$(node).daterangepicker(JSON.parse(configString),
                                                                                                                                          function(start, end, label) {
                                                                                                                                          _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onUpdateValue(Lcom/google/gwt/core/client/JsDate;Lcom/google/gwt/core/client/JsDate;)(start.toDate(),end.toDate());
                                                                                                                                          });
-
-
+                                                                                                                                         
+                                                                                                                                         
                                                                                                                                          $wnd.$(node).on('apply.daterangepicker', function(ev, picker) {
-                                                                                                                                         $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
+                                                                                                                                             $wnd.$(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
                                                                                                                                          });
 
 
-                                                                                                                                         $wnd.$('.bp-datetimerangepicker-resetbutton').on('click', function(ev, picker) {
-                                                                                                                                             $wnd.$('.bp-datetimerangepicker').val('');
-                                                                                                                                             _this.@org.vaadin.addons.datetimerangepicker.client.VDateTimeRangeField::onResetButtonClick()();
-                                                                                                                                         });
-
-
-                                                                                                                                         // $wnd.alert("Enabled ist: " + workable + "\nwnd: " + $wnd + "\n node: " + $wnd.$(node) + "\nThis" + this + "\nfirstElementChild " + this.firstElementChild + "\nElementId " + elementId + "\ndoc.getElementById(elementId) " + $doc.getElementById(elementId) +  "\ndisabled" +  $doc.getElementById(elementId).disabled);
                                                                                                                                          $doc.getElementById(elementId).disabled=!workable;
-
+                                                                                                                                         
                                                                                                                                          }-*/;
 
     private void onUpdateValue(final JsDate start, final JsDate end) {
         this.updateValueHandler.onUpdateValue(start, end);
     }
 
-    private void onResetButtonClick() {
-        this.updateValueHandler.onUpdateValue(null, null);
+    public static interface DateRangeFieldClientResetValueHandler extends EventHandler {
+        void onResetValue();
     }
-
-    // _
 
     public static interface DateRangeFieldClientUpdateValueHandler extends EventHandler {
         void onUpdateValue(JsDate start, JsDate end);
@@ -151,12 +148,12 @@ public class VDateTimeRangeField extends TextBoxBase {
         String dateLimit = "";
         if (dateLimitSpanMoment != null && !dateLimitSpanMoment.equals(VDateTimeRangeField.EMPTY_STRING)) {
             dateLimit = new StringBuilder().append("{ \"")
-                    .append(dateLimitSpanMoment)
+                .append(dateLimitSpanMoment)
 
-                    .append("\": ")
-                    .append(dateLimitSpanValue)
-                    .append(" }")
-                    .toString();
+                .append("\": ")
+                .append(dateLimitSpanValue)
+                .append(" }")
+                .toString();
         }
 
         // Ranges Processing
@@ -167,15 +164,15 @@ public class VDateTimeRangeField extends TextBoxBase {
             for (final Map.Entry<String, List<String>> entry : dateRanges.entrySet()) {
                 elementCount++;
                 ranges += new StringBuilder().append(" \"")
-                        .append(entry.getKey())
-                        .append("\": [\"")
-                        .append(entry.getValue()
-                                .get(0))
-                        .append("\", \"")
-                        .append(entry.getValue()
-                                .get(1))
-                        .append("\"]")
-                        .toString();
+                    .append(entry.getKey())
+                    .append("\": [\"")
+                    .append(entry.getValue()
+                        .get(0))
+                    .append("\", \"")
+                    .append(entry.getValue()
+                        .get(1))
+                    .append("\"]")
+                    .toString();
                 if (elementCount < dateRanges.size()) {
                     ranges += ",";
                 }
@@ -192,6 +189,6 @@ public class VDateTimeRangeField extends TextBoxBase {
         init(this.inputText, language, parentEl, startDate, endDate, minDate, maxDate, showDropdowns, showWeekNumbers, showISOWeekNumbers, singleDatePicker,
              timePicker, timePicker24Hour, timePickerIncrement, timePickerSeconds, dateLimit, autoApply, linkedCalendars, autoUpdateInput, opens, drops,
              buttonClasses, applyClass, cancelClass, ranges, alwaysShowCalendars, showCustomRangeLabels, applyLabel, cancelLabel, datePattern, workable,
-             this.elementId);
+             this.inputText.getId());
     }
 }

--- a/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/js/daterangepicker.js
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/js/daterangepicker.js
@@ -282,25 +282,10 @@
 
         var start, end, range;
 
-        //if no start/end dates set, check if an input element contains initial values
+        //if no start/end dates set, just set value of picket to zero string
         if (typeof options.startDate === 'undefined' && typeof options.endDate === 'undefined') {
             if ($(this.element).is('input[type=text]')) {
-                var val = $(this.element).val(),
-                    split = val.split(this.locale.separator);
-
-                start = end = null;
-
-                if (split.length == 2) {
-                    start = moment(split[0], this.locale.format);
-                    end = moment(split[1], this.locale.format);
-                } else if (this.singleDatePicker && val !== "") {
-                    start = moment(val, this.locale.format);
-                    end = moment(val, this.locale.format);
-                }
-                if (start !== null && end !== null) {
-                    this.setStartDate(start);
-                    this.setEndDate(end);
-                }
+            	$(this.element).val('');
             }
         }
 

--- a/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/public/vaadin-bootstrap-datetimerangepicker/styles.css
+++ b/vaadin-bootstrap-datetimerangepicker/src/main/resources/org/vaadin/addons/datetimerangepicker/public/vaadin-bootstrap-datetimerangepicker/styles.css
@@ -3,12 +3,6 @@
 	pointer-events: none;
 }
 
-.bp-datetimerangepicker .v-textfield {
-    padding-right: 35px;
-   /* width: 240px; */
-   width: 100%;
-}
-
 .bp-datetimerangepicker-v-disabled {
 	opacity: 0.5;
 }
@@ -18,16 +12,15 @@
 }
 
 .bp-datetimerangepicker-resetbutton {
-    position: relative;
+    position: absolute;
     display: inline-block;
-    right: -5px;
-    top: 11.5px;
-    margin-right: -20px;
     cursor: pointer;
     width: 16px;
-    height: 24px;
-    background-image: url('resetbutton-default.svg');    
-    background-repeat: no-repeat;    
+    height: 16px;
+    background-image: url(resetbutton-default.svg);
+    background-repeat: no-repeat;
+    margin-left: 6px;
+	margin-top: 4px;
 }
 
 .bp-datetimerangepicker-resetbutton:hover {


### PR DESCRIPTION
Some funtional and optical bugx were fixed:

1) The field has a space above and it's looks distorted

- first issue was space above the widget. This was produced by wrong styling of resetbutton. Bug fixed via changed css styling for reset button

- second issue was the small widgth of widgetset - the whole data range was too long to be seen. This was correctd by setting the widght style to 100% in the widget class

2) When more than 1 date range field is present and clear button is pressed - all date range pickers are cleared. Initially you cannot have empty date range picker aka Exception.

Problem solved by setting autoUpdateInput to false for cases, picker value was reseted (= empty) and true otherwise. Additionally startDate() and endDate() with null value for param must be called in cases, picker is reseted. Additionally some javascript stuff corrected for that: a) in VDateTimeRangeField.init() method, in case of startDate / endDate are undefined OR empty, '' value should be passed and b) in datapicker.js file proper logic corrected.

3) Another problem which is a stopper, after you clear the field (with the X button) in the code it's not empty. -> synchronized client && server side by adding proper onclicked event in the client side

Additionally (is no topic of that ticket), replaced hard coded elementId in the code by UUID && client side rpc class no needed.